### PR TITLE
Fixes critical WebSocket configuration gaps and async route handler errors.

### DIFF
--- a/src/http/core/request.ts
+++ b/src/http/core/request.ts
@@ -1055,8 +1055,15 @@ export class UwsRequest extends Readable {
    * Uses buffering mode for efficiency.
    * Caches the parsed result for subsequent calls.
    *
+   * For requests with empty bodies:
+   * - GET/HEAD/DELETE: Returns a frozen empty object `Object.freeze({})`
+   * - Other methods: Throws an error
+   *
+   * Note: The frozen empty object prevents accidental mutations and will throw
+   * a TypeError in strict mode if mutation is attempted.
+   *
    * @returns Promise that resolves with the parsed JSON object
-   * @throws Error if body is not valid JSON
+   * @throws Error if body is not valid JSON or if body is empty for non-GET/HEAD/DELETE methods
    */
   async json<T = unknown>(): Promise<T> {
     // Return cached result if available
@@ -1071,7 +1078,21 @@ export class UwsRequest extends Readable {
 
     // Create and cache the promise (buffer() handles mode switching)
     this.jsonPromise = this.buffer().then((buffer) => {
-      const text = buffer.toString('utf-8');
+      const text = buffer.toString('utf-8').trim();
+
+      // Handle empty body - return frozen empty object for GET/HEAD/DELETE, throw for all other methods
+      if (text === '') {
+        if (this.method === 'GET' || this.method === 'HEAD' || this.method === 'DELETE') {
+          // Freeze the empty object to prevent accidental mutations
+          // This will throw TypeError in strict mode if mutation is attempted
+          this.cachedJson = Object.freeze({}) as T;
+          return this.cachedJson as T;
+        }
+        // Throw for POST/PUT/PATCH and other methods (OPTIONS, SEARCH, PROPFIND, etc.)
+        throw new Error('Invalid JSON: Request body is empty', {
+          cause: new SyntaxError('Unexpected end of JSON input'),
+        });
+      }
 
       try {
         this.cachedJson = JSON.parse(text);

--- a/src/http/platform/uws-platform.adapter.ts
+++ b/src/http/platform/uws-platform.adapter.ts
@@ -35,9 +35,9 @@ type ResolvedPlatformOptions = {
   port: number;
   maxPayloadLength: number;
   idleTimeout: number;
+  maxLifetime: number;
   compression: uWS.CompressOptions;
   path: string;
-  perMessageDeflate: boolean;
   maxBackpressure: number;
   closeOnBackpressureLimit: boolean;
   sendPingsAutomatically: boolean;
@@ -132,9 +132,9 @@ export class UwsPlatformAdapter extends AbstractHttpAdapter {
       // WebSocket defaults (from v1.x)
       port: 8099,
       cors: undefined,
-      perMessageDeflate: false,
       maxPayloadLength: 16 * 1024,
       idleTimeout: 120,
+      maxLifetime: 0, // 0 = disabled (no lifetime limit)
       maxBackpressure: 1024 * 1024,
       closeOnBackpressureLimit: false,
       sendPingsAutomatically: true,

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -257,6 +257,14 @@ export class RouteRegistry {
           const requestPath = uwsReq.getUrl();
           const routesForWildcard = this.complexRoutesByWildcard.get(wildcardKey) || [];
 
+          // Create response wrapper early to attach abort handler
+          const res = new UwsResponse(uwsRes);
+
+          // Attach abort handler immediately to satisfy uWS requirement
+          res._onAbort(() => {
+            // Connection was aborted, nothing to do
+          });
+
           // Try to find a matching route
           let matched = false;
           for (const routeInfo of routesForWildcard) {
@@ -265,9 +273,8 @@ export class RouteRegistry {
             if (matches) {
               matched = true;
 
-              // Create request/response wrappers
+              // Create request wrapper
               const req = new UwsRequest(uwsReq, uwsRes, []);
-              const res = new UwsResponse(uwsRes);
 
               // Set extracted parameters using proper API
               req._setParams(matches);
@@ -290,7 +297,6 @@ export class RouteRegistry {
           // If no route matched, send 404
           if (!matched) {
             const req = new UwsRequest(uwsReq, uwsRes, []);
-            const res = new UwsResponse(uwsRes);
 
             // Handle CORS for unmatched routes (including preflight)
             if (this.corsHandler && (await this.corsHandler.handle(req, res))) {
@@ -343,10 +349,17 @@ export class RouteRegistry {
           const req = new UwsRequest(uwsReq, uwsRes, paramNames);
           const res = new UwsResponse(uwsRes);
 
+          // Attach abort handler immediately to satisfy uWS requirement
+          // This must be done before any async operations
+          res._onAbort(() => {
+            // Connection was aborted, nothing to do
+          });
+
           // Initialize body parser with configured size limit and fast abort option
           req._initBodyParser(
             this.options.maxBodySize ?? 1024 * 1024,
-            this.options.fastAbort ?? false
+            this.options.fastAbort ?? false,
+            res
           );
 
           // Execute handler with error handling
@@ -877,6 +890,11 @@ export class RouteRegistry {
       this.uwsApp.options('/*', async (uwsRes: uWS.HttpResponse, uwsReq: uWS.HttpRequest) => {
         const req = new UwsRequest(uwsReq, uwsRes, []);
         const res = new UwsResponse(uwsRes);
+
+        // Attach abort handler immediately to satisfy uWS requirement
+        res._onAbort(() => {
+          // Connection was aborted, nothing to do
+        });
 
         // Use this.corsHandler to pick up the latest handler
         if (this.corsHandler && (await this.corsHandler.handle(req, res))) {

--- a/src/websocket/adapter/uws.adapter.ts
+++ b/src/websocket/adapter/uws.adapter.ts
@@ -122,9 +122,13 @@ export class UwsAdapter implements WebSocketAdapter {
     this.options = {
       maxPayloadLength: options?.maxPayloadLength ?? 16 * 1024,
       idleTimeout: options?.idleTimeout ?? 60,
+      maxLifetime: options?.maxLifetime ?? 0, // 0 = disabled (no lifetime limit)
       compression: options?.compression ?? uWS.SHARED_COMPRESSOR,
       port: options?.port ?? 8099, // Default to 8099 if not provided
       path: options?.path ?? '/*',
+      maxBackpressure: options?.maxBackpressure ?? 1024 * 1024, // 1MB default
+      closeOnBackpressureLimit: options?.closeOnBackpressureLimit ?? false,
+      sendPingsAutomatically: options?.sendPingsAutomatically ?? true,
       cors: options?.cors,
       // SSL/TLS fields - carried through as-is (undefined when not supplied)
       cert_file_name: options?.cert_file_name,
@@ -233,6 +237,10 @@ export class UwsAdapter implements WebSocketAdapter {
         compression: this.options.compression,
         maxPayloadLength: this.options.maxPayloadLength,
         idleTimeout: this.options.idleTimeout,
+        maxLifetime: this.options.maxLifetime,
+        maxBackpressure: this.options.maxBackpressure,
+        closeOnBackpressureLimit: this.options.closeOnBackpressureLimit,
+        sendPingsAutomatically: this.options.sendPingsAutomatically,
 
         open: (ws: uWS.WebSocket<WebSocketClient>) => {
           const extWs = ws as ExtendedWebSocket;

--- a/src/websocket/interfaces/uws-options.interface.ts
+++ b/src/websocket/interfaces/uws-options.interface.ts
@@ -25,8 +25,53 @@ export interface UwsAdapterOptions {
   idleTimeout?: number;
 
   /**
+   * Maximum connection lifetime in minutes
+   *
+   * Maximum number of minutes a WebSocket connection may remain open before
+   * being automatically closed by the server. Set to 0 to disable this feature.
+   *
+   * This is useful for:
+   * - Forcing clients to reconnect periodically (load balancing)
+   * - Preventing indefinitely long connections
+   * - Ensuring clients get updated connection parameters
+   *
+   * @default 0 (disabled)
+   * @example
+   * ```typescript
+   * // Close connections after 24 hours
+   * maxLifetime: 24 * 60  // 1440 minutes
+   *
+   * // Close connections after 1 hour
+   * maxLifetime: 60
+   *
+   * // Disable (allow indefinite connections)
+   * maxLifetime: 0
+   * ```
+   */
+  maxLifetime?: number;
+
+  /**
    * Compression mode
+   *
+   * Controls per-message deflate compression for WebSocket messages.
+   *
+   * Options:
+   * - `uWS.DISABLED` - No compression (lowest CPU, highest bandwidth)
+   * - `uWS.SHARED_COMPRESSOR` - Shared compressor across connections (balanced)
+   * - `uWS.DEDICATED_COMPRESSOR_3KB` to `_256KB` - Dedicated per-connection (highest compression)
+   *
    * @default uWS.SHARED_COMPRESSOR
+   * @example
+   * ```typescript
+   * // Disable compression for low-latency requirements
+   * compression: uWS.DISABLED
+   *
+   * // Enable shared compression (default, recommended)
+   * compression: uWS.SHARED_COMPRESSOR
+   *
+   * // Maximum compression for bandwidth-constrained environments
+   * compression: uWS.DEDICATED_COMPRESSOR_256KB
+   * ```
    */
   compression?: uWS.CompressOptions;
 
@@ -35,6 +80,64 @@ export interface UwsAdapterOptions {
    * @default '/*'
    */
   path?: string;
+
+  /**
+   * Maximum backpressure (buffered bytes) per WebSocket connection
+   *
+   * When a client is slow to receive data, messages are buffered. If the buffer exceeds this limit:
+   * - If `closeOnBackpressureLimit` is true: connection is closed
+   * - If `closeOnBackpressureLimit` is false: messages continue to buffer (may cause memory issues)
+   *
+   * @default 1048576 (1MB)
+   * @example
+   * ```typescript
+   * // Allow 5MB of buffered data per connection
+   * maxBackpressure: 5 * 1024 * 1024
+   *
+   * // Strict limit for memory-constrained environments
+   * maxBackpressure: 512 * 1024  // 512KB
+   * ```
+   */
+  maxBackpressure?: number;
+
+  /**
+   * Close connection when backpressure limit is exceeded
+   *
+   * When true, connections that exceed `maxBackpressure` are automatically closed.
+   * When false, messages continue to buffer (may cause memory issues with slow clients).
+   *
+   * @default false
+   * @example
+   * ```typescript
+   * // Protect server from slow clients
+   * maxBackpressure: 1024 * 1024,
+   * closeOnBackpressureLimit: true
+   *
+   * // Allow unlimited buffering (use with caution)
+   * closeOnBackpressureLimit: false
+   * ```
+   */
+  closeOnBackpressureLimit?: boolean;
+
+  /**
+   * Automatically send ping frames to keep connections alive
+   *
+   * When enabled, the server automatically sends WebSocket ping frames to detect
+   * dead connections. Clients must respond with pong frames or the connection
+   * will be closed after `idleTimeout` seconds.
+   *
+   * @default true
+   * @example
+   * ```typescript
+   * // Enable automatic pings (recommended)
+   * sendPingsAutomatically: true,
+   * idleTimeout: 120  // Close if no pong received within 120s
+   *
+   * // Disable if client handles pings manually
+   * sendPingsAutomatically: false
+   * ```
+   */
+  sendPingsAutomatically?: boolean;
 
   /**
    * CORS configuration
@@ -160,6 +263,11 @@ export interface ResolvedUwsAdapterOptions {
   idleTimeout: number;
 
   /**
+   * Maximum connection lifetime in minutes
+   */
+  maxLifetime: number;
+
+  /**
    * Compression mode
    */
   compression: uWS.CompressOptions;
@@ -168,6 +276,21 @@ export interface ResolvedUwsAdapterOptions {
    * WebSocket endpoint path
    */
   path: string;
+
+  /**
+   * Maximum backpressure (buffered bytes) per WebSocket connection
+   */
+  maxBackpressure: number;
+
+  /**
+   * Close connection when backpressure limit is exceeded
+   */
+  closeOnBackpressureLimit: boolean;
+
+  /**
+   * Automatically send ping frames to keep connections alive
+   */
+  sendPingsAutomatically: boolean;
 
   /**
    * CORS configuration


### PR DESCRIPTION
## WebSocket Configuration (Fixes #31)
Exposed 4 missing WebSocket options that were used internally but not available in the interface:

- `maxBackpressure` - Maximum buffered bytes per connection (default: 1MB)
- `maxLifetime` - Automatically closes WebSocket connections after a specified number of minutes, regardless of activity
- `closeOnBackpressureLimit` - Auto-close slow clients exceeding buffer limit
- `sendPingsAutomatically` - Enable automatic ping frames for connection health

All options now properly documented with `JSDoc` and applied in `UwsAdapter` constructor.

## Async Route Handler Fix (Fixes #30)

**Root cause:** `uWebSockets.js` requires either synchronous response OR abort handler attachment before async operations.

**Solution:** Attach `res._onAbort()` handler immediately at the start of route handlers in 3 locations:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket connections gain new configuration options: max lifetime, backpressure limits, close-on-backpressure, and automatic pings; compression behavior clarified.

* **Bug Fixes**
  * JSON request parsing now trims whitespace and handles empty bodies: returns an empty object for safe methods and reports invalid JSON for body-bearing methods.

* **Refactor**
  * Request routing now registers abort handling earlier to improve request lifecycle reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->