### PR TITLE
Fix duplicate Content-Length header in `CompressionHandler.compressBuffer()`

### DIFF
--- a/src/http/handlers/compression/compression-handler.spec.ts
+++ b/src/http/handlers/compression/compression-handler.spec.ts
@@ -817,9 +817,10 @@ describe('CompressionHandler', () => {
       expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'gzip');
     });
 
-    it('should update Content-Length to compressed size', async () => {
+    it('should compress data without setting Content-Length', async () => {
       const handler = new CompressionHandler();
       setupMock('gzip', 'text/plain');
+      const removeHeaderSpy = jest.spyOn(mockRes, 'removeHeader');
 
       const result = await handler.compressBuffer(
         mockReq as UwsRequest,
@@ -827,8 +828,12 @@ describe('CompressionHandler', () => {
         LARGE_DATA
       );
 
-      // Verify Content-Length was set to compressed size
-      expect(setHeaderSpy).toHaveBeenCalledWith('content-length', result.length.toString());
+      // Verify content-length was NOT set (to avoid duplicates - send() handles it)
+      expect(setHeaderSpy).not.toHaveBeenCalledWith('content-length', expect.anything());
+      // Verify content-encoding and vary were set
+      expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'gzip');
+      expect(removeHeaderSpy).toHaveBeenCalledWith('content-length');
+      // Verify data was actually compressed
       expect(result.length).toBeLessThan(LARGE_DATA.length);
     });
 

--- a/src/http/handlers/compression/compression-handler.ts
+++ b/src/http/handlers/compression/compression-handler.ts
@@ -333,8 +333,8 @@ export class CompressionHandler {
 
       stream.on('end', () => {
         const compressed = Buffer.concat(chunks);
-        // Update Content-Length to match compressed size
-        res.setHeader('content-length', compressed.length.toString());
+        // Don't set content-length here - let send() handle it based on body size
+        // This avoids duplicate content-length headers
         resolve(compressed);
       });
 


### PR DESCRIPTION
Remove `res.setHeader('content-length', ...)` from `compressBuffer()`. Let `send()` handle it automatically based on the returned buffer size.

Fix #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response header management during content compression to prevent duplicate headers and ensure accurate content size information is communicated to clients when responses are compressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->