### PR TITLE
Add streaming benchmark scenarios

### DIFF
--- a/benchmarks/scenarios/streaming-upload.js
+++ b/benchmarks/scenarios/streaming-upload.js
@@ -1,0 +1,56 @@
+'use strict';
+
+module.exports = {
+  name: 'streaming-upload',
+  path: '/hash-body',
+  wrk: {
+    script: 'post-hash-body.lua',
+    connections: 25,
+  },
+  setup(app, framework) {
+    const crypto = require('crypto');
+
+    function createHashFromRequest(req, callback) {
+      const hash = crypto.createHash('sha256');
+      req.on('data', (chunk) => {
+        hash.update(chunk);
+      });
+      req.on('end', () => {
+        callback(hash.digest('hex'), null);
+      });
+      req.on('error', (error) => {
+        callback(null, error);
+      });
+    }
+
+    if (framework === 'fastify') {
+      // Register no-op content type parser for application/octet-stream
+      // This prevents Fastify from rejecting with 415 Unsupported Media Type
+      // Without parseAs, Fastify doesn't buffer the stream (bodyLimit doesn't apply)
+      app.addContentTypeParser('application/octet-stream', function (_request, _payload, done) {
+        done();
+      });
+
+      app.post('/hash-body', (req, reply) => {
+        createHashFromRequest(req.raw, (digest, error) => {
+          if (error) {
+            reply.code(500).send({ error: error.message });
+            return;
+          }
+          reply.type('text/plain').send(digest);
+        });
+      });
+    } else {
+      // Express and uWestJS use same API
+      app.post('/hash-body', (req, res) => {
+        createHashFromRequest(req, (digest, error) => {
+          if (error) {
+            res.status(500).type('text/plain').send('Error processing upload');
+            return;
+          }
+          res.type('text/plain').send(digest);
+        });
+      });
+    }
+  },
+};

--- a/benchmarks/scenarios/streaming-with-content-length.js
+++ b/benchmarks/scenarios/streaming-with-content-length.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { Readable } = require('stream');
+
+module.exports = {
+  name: 'streaming-with-content-length',
+  path: '/stream-with-content-length',
+  wrk: {
+    connections: 20,
+  },
+  setup(app, framework) {
+    const STREAM_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+    const STREAM_CHUNK_SIZE = 64 * 1024; // 64KB
+    const STREAM_CHUNK = Buffer.alloc(STREAM_CHUNK_SIZE, 'x');
+
+    function createStream() {
+      let remaining = STREAM_SIZE_BYTES;
+      return new Readable({
+        read() {
+          if (remaining <= 0) {
+            this.push(null);
+            return;
+          }
+
+          const chunk =
+            remaining >= STREAM_CHUNK_SIZE ? STREAM_CHUNK : STREAM_CHUNK.subarray(0, remaining);
+          remaining -= chunk.length;
+          this.push(chunk);
+        },
+      });
+    }
+
+    if (framework === 'fastify') {
+      app.get('/stream-with-content-length', (_req, reply) => {
+        reply.header('Content-Length', String(STREAM_SIZE_BYTES));
+        reply.header('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        reply.send(stream);
+      });
+    } else if (framework === 'express') {
+      app.get('/stream-with-content-length', (_req, res) => {
+        res.setHeader('Content-Length', String(STREAM_SIZE_BYTES));
+        res.setHeader('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        stream.pipe(res);
+      });
+    } else if (framework === 'uwestjs') {
+      app.get('/stream-with-content-length', async (_req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        await res.stream(stream, STREAM_SIZE_BYTES);
+      });
+    }
+  },
+};

--- a/benchmarks/scenarios/streaming-without-content-length.js
+++ b/benchmarks/scenarios/streaming-without-content-length.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { Readable } = require('stream');
+
+module.exports = {
+  name: 'streaming-without-content-length',
+  path: '/stream-without-content-length',
+  wrk: {
+    connections: 20,
+  },
+  setup(app, framework) {
+    const STREAM_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+    const STREAM_CHUNK_SIZE = 64 * 1024; // 64KB
+    const STREAM_CHUNK = Buffer.alloc(STREAM_CHUNK_SIZE, 'x');
+
+    function createStream() {
+      let remaining = STREAM_SIZE_BYTES;
+      return new Readable({
+        read() {
+          if (remaining <= 0) {
+            this.push(null);
+            return;
+          }
+
+          const chunk =
+            remaining >= STREAM_CHUNK_SIZE ? STREAM_CHUNK : STREAM_CHUNK.subarray(0, remaining);
+          remaining -= chunk.length;
+          this.push(chunk);
+        },
+      });
+    }
+
+    if (framework === 'fastify') {
+      app.get('/stream-without-content-length', (_req, reply) => {
+        reply.header('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        reply.send(stream);
+      });
+    } else if (framework === 'express') {
+      app.get('/stream-without-content-length', (_req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        stream.pipe(res);
+      });
+    } else if (framework === 'uwestjs') {
+      app.get('/stream-without-content-length', async (_req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream');
+        const stream = createStream();
+        await res.stream(stream);
+      });
+    }
+  },
+};

--- a/benchmarks/wrk-scripts/post-hash-body.lua
+++ b/benchmarks/wrk-scripts/post-hash-body.lua
@@ -1,0 +1,7 @@
+wrk.method = "POST"
+wrk.path = "/hash-body"
+wrk.headers["Content-Type"] = "application/octet-stream"
+
+local mb = 1024 * 1024
+local body = string.rep("a", 4 * mb)
+wrk.body = body

--- a/src/http/core/request.ts
+++ b/src/http/core/request.ts
@@ -372,8 +372,7 @@ export class UwsRequest extends Readable {
     // This handles non-pipe consumers (e.g., for await...of, .read(), etc.)
     if (!this.streamActivated && this.bodyParserMode === 'awaiting') {
       this.activateStreaming();
-      // Note: activateStreaming() overrides this._read, but this call already started
-      // so we need to resume here too
+      // activateStreaming() handles _read override and initial resume
       return;
     }
 


### PR DESCRIPTION
## Add streaming benchmark scenarios

Adds comprehensive streaming benchmarks to measure performance of large data transfers.

### Changes

**New Scenarios:**
- `streaming-with-content-length.js` - 5MB response stream with Content-Length header (optimal `tryEnd()` path)
- `streaming-without-content-length.js` - 5MB response stream with chunked transfer encoding
- `streaming-upload.js` - 4MB POST request body streaming with SHA-256 hash computation

**New Assets:**
- `wrk-scripts/post-hash-body.lua` - Lua script for POST streaming benchmark

Closes #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark scenarios for streaming uploads with hash computation performance measurement
  * Added benchmark scenarios to evaluate streaming performance with and without Content-Length headers
  * Added performance measurement scripts for POST request streaming across multiple web frameworks (Fastify, Express, uWestJS)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->