### PR TITLE
fix(multipart): prevent options.headers from overriding request headers

### DIFF
--- a/src/http/body/multipart-handler.spec.ts
+++ b/src/http/body/multipart-handler.spec.ts
@@ -122,6 +122,27 @@ describe('MultipartFormHandler', () => {
       expect(fields[1]).toMatchObject({ name: 'email', value: 'vikram@example.com' });
     });
 
+    it('should use request headers when options include headers', async () => {
+      const boundary = createBoundary();
+      const body = createMultipartBody(boundary, [{ name: 'name', value: 'Vikram Aditya' }]);
+
+      const req = setupMultipartRequest(boundary, body.length);
+      const handler = new MultipartFormHandler(req, {
+        headers: { 'content-type': 'something-wrong' } as any,
+      });
+
+      const fields: MultipartField[] = [];
+      const parsePromise = handler.parse(async (field) => {
+        fields.push(field);
+      });
+
+      sendMultipartData(body);
+      await parsePromise;
+
+      expect(fields).toHaveLength(1);
+      expect(fields[0]).toMatchObject({ name: 'name', value: 'Vikram Aditya' });
+    });
+
     it('should parse file fields', async () => {
       const boundary = createBoundary();
       const fileContent = 'Hello, World!';

--- a/src/http/body/multipart-handler.ts
+++ b/src/http/body/multipart-handler.ts
@@ -136,8 +136,8 @@ export class MultipartFormHandler {
       let uploader: busboy.Busboy;
       try {
         uploader = busboy({
-          headers: this.request.headers,
           ...this.options,
+          headers: this.request.headers,
         });
       } catch (err) {
         reject(new Error(`Invalid multipart Content-Type: ${(err as Error).message}`));


### PR DESCRIPTION
Closes #73.

`MultipartFormHandler` constructed the busboy parser with `headers: this.request.headers` first, then spread `this.options` on top. If a caller passed a `headers` field inside the options object — even by accident — that user-supplied `headers` overrode the actual request headers. Busboy reads the multipart boundary from the `Content-Type` header, so this broke parsing for any caller whose options happened to include `headers`.

## Fix

Swap the spread order so the request headers always win:

```ts
busboy({
  ...this.options,
  headers: this.request.headers,
});
```

The request headers are non-negotiable for multipart parsing — the boundary lives in `Content-Type`. Any `headers` value inside the options object is almost certainly accidental, so giving the runtime values precedence matches the expectation.

## Verification

Adds a regression test that constructs the handler with `{ headers: { 'content-type': 'something-wrong' } }` in options, sends a valid multipart body on the request, and asserts the single field is delivered correctly. The new test joins the existing 19 multipart tests; all 20 pass under `npx jest src/http/body/multipart-handler.spec.ts`.

`npm run lint` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multipart parser header precedence: request headers now correctly override configuration options during multipart form data parsing, ensuring reliable data extraction.

* **Tests**
  * Added test case verifying multipart parsing succeeds with correct request headers even when configuration options contain incorrect or conflicting header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->