### PR TITLE
fix(cors): reject preflight immediately if any requested header is disallowed

### DIFF
--- a/src/http/handlers/cors/cors-handler.spec.ts
+++ b/src/http/handlers/cors/cors-handler.spec.ts
@@ -378,12 +378,13 @@ describe('CorsHandler', () => {
       expect(sendSpy).toHaveBeenCalled();
     });
 
-    it('should reject preflight with 403 when requested headers are not allowed', async () => {
+    it('should reject preflight with 403 when ANY requested header is not allowed', async () => {
       const handler = new CorsHandler({
         allowedHeaders: ['Content-Type', 'Authorization'],
       });
       setupRequest('https://example.com', 'OPTIONS');
-      mockReq.headers!['access-control-request-headers'] = 'X-Custom-Header, X-Forbidden';
+      // Content-Type is allowed, but X-Forbidden is not
+      mockReq.headers!['access-control-request-headers'] = 'Content-Type, X-Forbidden';
 
       const handled = await handleCors(handler);
 

--- a/src/http/handlers/cors/cors-handler.ts
+++ b/src/http/handlers/cors/cors-handler.ts
@@ -162,14 +162,14 @@ export class CorsHandler {
       // User explicitly configured allowedHeaders - validate requested headers
       const requested = requestedHeaders.split(',').map((h) => h.trim().toLowerCase());
       const allowed = this.options.allowedHeaders.map((h) => h.toLowerCase());
-      const validated = requested.filter((h) => allowed.includes(h));
+      const isValid = requested.every((h) => allowed.includes(h));
 
-      if (validated.length === 0) {
-        // Requested headers not allowed - reject preflight
+      if (!isValid) {
+        // One or more requested headers are not allowed - reject preflight
         res.status(403).send();
         return true;
       }
-      allowedHeadersToSend = validated.join(', ');
+      allowedHeadersToSend = requested.join(', ');
     } else if (requestedHeaders) {
       // No allowedHeaders configured or empty array - echo back (permissive mode)
       allowedHeadersToSend = requestedHeaders;


### PR DESCRIPTION
I have fixed the issue where the CORS preflight would incorrectly return a successful 200/204 response when a mix of allowed and disallowed headers were requested.

What was changed:
I've updated src/http/handlers/cors/cors-handler.ts to strictly validate Access-Control-Request-Headers. The handler now ensures that every single header in the requested list is present in the allowedHeaders. If any requested header is missing from the allowed list, the preflight request is immediately rejected.

I've also updated the tests in src/http/handlers/cors/cors-handler.spec.ts to add a test case verifying this exact scenario

related issue - https://github.com/FOSSFORGE/uWestJS/issues/76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS preflight header validation: the handler now strictly validates that all requested headers are in the allowed list and rejects requests if any requested header is not permitted. When valid, the original requested header list is properly echoed in the response.

* **Tests**
  * Updated CORS preflight test cases to verify stricter header validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #76 