### PR TITLE
Fix: misleading example in `etagFn` documentation

### DIFF
--- a/src/http/handlers/static/static-file-handler.ts
+++ b/src/http/handlers/static/static-file-handler.ts
@@ -125,17 +125,16 @@ export interface StaticFileOptions {
    * which creates ETags based on file statistics (size and modification time).
    *
    * You can provide a custom function to override the default behavior.
-   * For example, to generate content-based ETags using file hashing:
+   * For example:
    *
    * ```ts
    * etagFn: (stat) => {
-   *   const hash = crypto.createHash('md5').update(fileContent).digest('hex');
-   *   return `"${hash}"`;
+   *   return `"${stat.size.toString(16)}-${stat.mtimeMs.toString(16)}"`;
    * }
    * ```
    *
-   * Note: Content-based ETags require reading the entire file, which impacts performance.
-   * The default stat-based approach is much faster and suitable for most use cases.
+   * Note: The 'etagFn' only recieves file stats (`fs.Stats`) and does not have access
+   * to file content.
    */
   etagFn?: (stat: fs.Stats) => string;
 


### PR DESCRIPTION
This PR fixes a misleading `etagFn` example in the documentation.

The previous example referenced `fileContent`, which is not available in the function signature and would result in a ReferenceError.

Updated the example to use file metadata (`stat.size` and `stat.mtimeMs`), which are actually available.

Also clarified that `etagFn` only receives `fs.Stats` and not file content.

Fixes #77 