### PR TITLE
test(multipart): remove redundant jest.useRealTimers in async handlers test

### DIFF
--- a/src/http/body/multipart-handler.spec.ts
+++ b/src/http/body/multipart-handler.spec.ts
@@ -264,8 +264,6 @@ describe('MultipartFormHandler', () => {
       // Verify pause/resume were called for backpressure
       expect(mockUwsRes.pause).toHaveBeenCalled();
       expect(mockUwsRes.resume).toHaveBeenCalled();
-
-      jest.useRealTimers();
     });
 
     it('should handle synchronous handlers without backpressure', async () => {


### PR DESCRIPTION
## Summary

Resolves #87. The "backpressure handling" describe block in `src/http/body/multipart-handler.spec.ts` already restores real timers via the `afterEach` hook at line 235. The explicit `jest.useRealTimers()` at line 268 inside `should handle async handlers sequentially` was redundant — it ran the same call the hook would run a moment later.

## Why this matters

The issue noted the inconsistency directly: the second test in the same block (`should handle synchronous handlers without backpressure`) does not call `jest.useRealTimers()` manually, so the two sibling tests treated cleanup differently. Both rely on the shared `afterEach` for fake-timer reset, which is the right pattern. Keeping the redundant call would have been a small future trap — anyone touching the second test could reasonably read the first one as "this test needs an explicit reset" and copy-paste the pattern.

I confirmed the redundant call is still on `main` at line 268 (a recent comment on the issue suggested it had already been removed; running `grep -n "jest.useRealTimers" src/http/body/multipart-handler.spec.ts` against `upstream/main` showed lines 235, 268, 536 — line 268 is the one inside the test body).

## Testing

- `npx jest src/http/body/multipart-handler.spec.ts` — 19/19 pass.
- `npm run lint` — clean.

Fixes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for backpressure handling in multipart processing with additional assertions for pause and resume behavior during async handler execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->