### PR TITLE
fix(websocket): throw on ExecutionContext.switchToRpc()

### DIFF
--- a/src/websocket/middleware/filters/exception-filter-executor.spec.ts
+++ b/src/websocket/middleware/filters/exception-filter-executor.spec.ts
@@ -143,6 +143,24 @@ describe('ExceptionFilterExecutor', () => {
       expect(receivedHost!.switchToWs().getData()).toBe(data);
     });
 
+    it('should throw when switching to RPC context', async () => {
+      expect.assertions(1);
+
+      class RpcCheckFilter implements ExceptionFilter {
+        catch(_exception: Error, host: ArgumentsHost): void {
+          expect(() => host.switchToRpc()).toThrow('RPC context not available in WebSocket');
+        }
+      }
+
+      class TestGateway {
+        @UseFilters(RpcCheckFilter)
+        handleMessage() {}
+      }
+
+      const host = createHost(new TestGateway());
+      await executor.catch(new Error('Test'), host);
+    });
+
     it('should provide correct getArgs and getArgByIndex', async () => {
       let receivedHost: ArgumentsHost | null = null;
 

--- a/src/websocket/middleware/filters/exception-filter-executor.ts
+++ b/src/websocket/middleware/filters/exception-filter-executor.ts
@@ -124,10 +124,9 @@ export class ExceptionFilterExecutor {
     return {
       getArgs: <T extends unknown[] = unknown[]>() => args as T,
       getArgByIndex: <T = unknown>(index: number): T => args[index] as T,
-      switchToRpc: () => ({
-        getContext: () => host.client,
-        getData: () => host.data,
-      }),
+      switchToRpc: () => {
+        throw new Error('RPC context not available in WebSocket');
+      },
       switchToHttp: () => {
         throw new Error('HTTP context not available in WebSocket');
       },

--- a/src/websocket/middleware/guards/guard-executor.spec.ts
+++ b/src/websocket/middleware/guards/guard-executor.spec.ts
@@ -233,6 +233,26 @@ describe('GuardExecutor', () => {
       expect(wsContext!.getPattern()).toBe('handleMessage');
     });
 
+    it('should throw when switching to RPC context', async () => {
+      class RpcCheckGuard implements CanActivate {
+        canActivate(context: ExecutionContext): boolean {
+          context.switchToRpc();
+          return true;
+        }
+      }
+
+      class TestGateway {
+        @UseGuards(RpcCheckGuard)
+        handleMessage() {}
+      }
+
+      const context = createContext(new TestGateway());
+
+      await expect(executor.executeGuards(context)).rejects.toThrow(
+        'RPC context not available in WebSocket'
+      );
+    });
+
     it('should provide correct getArgByIndex for valid and invalid indices', async () => {
       let receivedContext: ExecutionContext | null = null;
 

--- a/src/websocket/middleware/guards/guard-executor.ts
+++ b/src/websocket/middleware/guards/guard-executor.ts
@@ -134,10 +134,9 @@ export class GuardExecutor {
         const args = [context.client, context.data];
         return args[index];
       },
-      switchToRpc: () => ({
-        getContext: () => context.client,
-        getData: () => context.data,
-      }),
+      switchToRpc: () => {
+        throw new Error('RPC context not available in WebSocket');
+      },
       switchToHttp: () => {
         throw new Error('HTTP context not available in WebSocket');
       },


### PR DESCRIPTION
## What changed

`src/websocket/middleware/guards/guard-executor.ts` and `src/websocket/middleware/filters/exception-filter-executor.ts`: replaced the `switchToRpc` adapter (which previously returned a fake RPC context wrapping the WebSocket client and data) with a throwing implementation that mirrors the existing `switchToHttp` behavior:

```ts
switchToRpc: () => {
  throw new Error('RPC context not available in WebSocket');
},
```

Added two unit tests — one in `guard-executor.spec.ts`, one in `exception-filter-executor.spec.ts` — that build a guard / filter calling `context.switchToRpc()` and assert the throw.

Closes #89

## Why

Issue #89 calls out that the existing `switchToRpc` returns a fake context whose `getContext()` and `getData()` map WebSocket fields into RPC slots. That's semantically wrong — the execution context is never an RPC context. The expected behavior, per the NestJS reference linked in the issue (`packages/core/helpers/execution-context-host.ts`), is that the wrong-context switches throw. The codebase already does this for `switchToHttp`; this PR makes `switchToRpc` symmetric.

## Verification

`npx jest src/websocket/middleware/guards/guard-executor.spec.ts src/websocket/middleware/filters/exception-filter-executor.spec.ts` runs 33/33 green, including the two new tests. The new tests use the same gateway construction and execution invocation pattern as the existing `switchToWs` tests in those files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket exception and guard handlers now throw a clear error when attempting to access RPC context, preventing unsupported operations.

* **Tests**
  * Added test coverage for WebSocket RPC context restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->