### PR TITLE
Fix #94 Return proper status code for large responses and #95 Support decompression

### DIFF
--- a/src/http/core/request.spec.ts
+++ b/src/http/core/request.spec.ts
@@ -4,6 +4,8 @@ import { UwsRequest } from './request';
 import { toArrayBuffer, createMockResponse } from '../test-helpers';
 import * as signature from 'cookie-signature';
 import type { MultipartField } from '../body/multipart-handler';
+import * as zlib from 'zlib';
+import { promisify } from 'util';
 
 describe('UwsRequest', () => {
   let mockUwsReq: jest.Mocked<HttpRequest>;
@@ -587,6 +589,261 @@ describe('UwsRequest', () => {
 
       // Should reject with size limit error
       await expect(bufferPromise).rejects.toThrow('Body size limit exceeded');
+    });
+
+    it('should fallback to close() when 413 response fails', async () => {
+      // Set content-length larger than limit
+      setHeaders(['content-length', '2000']);
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+
+      // Create a mock response that throws when trying to send 413
+      const mockResponse = {
+        ...createMockResponse(),
+        headersSent: false,
+        status: jest.fn().mockReturnValue({
+          send: jest.fn().mockImplementation(() => {
+            throw new Error('Connection already closed');
+          }),
+        }),
+      };
+
+      req._initBodyParser(1000, false, mockResponse as any);
+
+      // Should fallback to close() when send() fails
+      expect(mockUwsRes.close).toHaveBeenCalled();
+      expect(req.isAborted).toBe(true);
+    });
+
+    it('should use close() in fast abort mode instead of sending 413', async () => {
+      // Set content-length larger than limit
+      setHeaders(['content-length', '2000']);
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+
+      // Enable fast abort mode
+      req._initBodyParser(1000, true, mockResponse as any);
+
+      // Should close immediately in fast abort mode
+      expect(mockUwsRes.close).toHaveBeenCalled();
+      // In fast abort mode, we don't try to send a response
+      // The connection is just closed immediately
+    });
+  });
+
+  describe('decompression', () => {
+    it('should signal EOF to streaming consumers when decompression ends', async () => {
+      const gzip = promisify(zlib.gzip);
+
+      // Create compressed data
+      const originalData = 'Hello World from compressed stream';
+      const compressedData = await gzip(Buffer.from(originalData));
+
+      setHeaders(
+        ['content-type', 'text/plain'],
+        ['content-encoding', 'gzip'],
+        ['content-length', compressedData.length.toString()]
+      );
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+      req._initBodyParser(1024 * 1024, false, mockResponse as any);
+
+      // Activate streaming mode by piping
+      const chunks: Buffer[] = [];
+      let streamEnded = false;
+
+      const writable = new Writable({
+        write(chunk: Buffer, encoding: string, callback: () => void) {
+          chunks.push(chunk);
+          callback();
+        },
+      });
+
+      writable.on('finish', () => {
+        streamEnded = true;
+      });
+
+      req.pipe(writable);
+
+      // Send compressed data
+      onDataCallback(toArrayBuffer(compressedData), true);
+
+      // Wait for decompression to complete
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify stream received EOF signal
+      expect(streamEnded).toBe(true);
+      expect(Buffer.concat(chunks).toString()).toBe(originalData);
+    });
+
+    it('should handle decompression in buffering mode', async () => {
+      const gzip = promisify(zlib.gzip);
+
+      const originalData = '{"message":"compressed json"}';
+      const compressedData = await gzip(Buffer.from(originalData));
+
+      setHeaders(
+        ['content-type', 'application/json'],
+        ['content-encoding', 'gzip'],
+        ['content-length', compressedData.length.toString()]
+      );
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+      req._initBodyParser(1024 * 1024, false, mockResponse as any);
+
+      // Use json() to activate buffering mode
+      const jsonPromise = req.json();
+
+      // Send compressed data
+      onDataCallback(toArrayBuffer(compressedData), true);
+
+      // Wait for decompression
+      const result = await jsonPromise;
+
+      expect(result).toEqual({ message: 'compressed json' });
+    });
+
+    it('should enforce size limit on decompressed data', async () => {
+      const gzip = promisify(zlib.gzip);
+
+      // Create data that's small when compressed but large when decompressed
+      const originalData = 'x'.repeat(1000); // 1000 bytes uncompressed
+      const compressedData = await gzip(Buffer.from(originalData));
+
+      setHeaders(
+        ['content-type', 'text/plain'],
+        ['content-encoding', 'gzip'],
+        ['content-length', compressedData.length.toString()]
+      );
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+
+      // Track if error was emitted
+      let errorEmitted = false;
+      req.on('error', () => {
+        errorEmitted = true;
+      });
+
+      // Set limit to 500 bytes (less than decompressed size)
+      req._initBodyParser(500, false, mockResponse as any);
+
+      // Send compressed data
+      onDataCallback(toArrayBuffer(compressedData), true);
+
+      // Wait for decompression to detect size limit
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should have closed connection due to size limit
+      expect(mockUwsRes.close).toHaveBeenCalled();
+      expect(errorEmitted).toBe(true);
+    });
+
+    it('should handle backpressure from decompression stream', async () => {
+      const gzip = promisify(zlib.gzip);
+
+      // Create compressed data
+      const originalData = 'test data for backpressure';
+      const compressedData = await gzip(Buffer.from(originalData));
+
+      setHeaders(
+        ['content-type', 'text/plain'],
+        ['content-encoding', 'gzip'],
+        ['content-length', compressedData.length.toString()]
+      );
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+      req._initBodyParser(1024 * 1024, false, mockResponse as any);
+
+      // Track pause/resume calls
+      let pauseCalled = false;
+      let resumeCalled = false;
+      const originalPause = mockUwsRes.pause;
+      const originalResume = mockUwsRes.resume;
+
+      mockUwsRes.pause = jest.fn(() => {
+        pauseCalled = true;
+        return originalPause.call(mockUwsRes);
+      });
+
+      mockUwsRes.resume = jest.fn(() => {
+        resumeCalled = true;
+        return originalResume.call(mockUwsRes);
+      });
+
+      // Mock the decompression stream write to return false (backpressure)
+      const decompressionStream = req['decompressionStream']!;
+      const originalWrite = decompressionStream.write.bind(decompressionStream);
+
+      let firstWrite = true;
+      decompressionStream.write = jest.fn((chunk: any, encoding?: any, callback?: any): boolean => {
+        if (firstWrite) {
+          firstWrite = false;
+          // Simulate backpressure - emit drain after a short delay
+          setImmediate(() => decompressionStream.emit('drain'));
+          return false; // Signal backpressure
+        }
+        return originalWrite(chunk, encoding, callback);
+      }) as any;
+
+      // Send first chunk (will trigger backpressure)
+      onDataCallback(toArrayBuffer(compressedData.slice(0, 10)), false);
+
+      // Wait for drain event to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Send remaining data
+      onDataCallback(toArrayBuffer(compressedData.slice(10)), true);
+
+      // Wait for decompression
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Verify pause was called when backpressure detected
+      expect(pauseCalled).toBe(true);
+      // Verify resume was called after drain
+      expect(resumeCalled).toBe(true);
+    });
+
+    it('should set aborted flag on decompression error to prevent writes to destroyed stream', async () => {
+      // Create invalid compressed data (will cause decompression error)
+      const invalidCompressedData = Buffer.from('not valid gzip data');
+
+      setHeaders(
+        ['content-type', 'text/plain'],
+        ['content-encoding', 'gzip'],
+        ['content-length', invalidCompressedData.length.toString()]
+      );
+
+      const req = new UwsRequest(mockUwsReq, mockUwsRes);
+      const mockResponse = createMockResponse();
+
+      // Track error
+      let errorEmitted = false;
+      req.on('error', () => {
+        errorEmitted = true;
+      });
+
+      req._initBodyParser(1024 * 1024, false, mockResponse as any);
+
+      // Send invalid compressed data
+      onDataCallback(toArrayBuffer(invalidCompressedData), false);
+
+      // Wait for decompression error
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Verify aborted flag is set
+      expect(req.isAborted).toBe(true);
+      expect(errorEmitted).toBe(true);
+
+      // Try to send more data - should be ignored due to aborted flag
+      const moreData = Buffer.from('more data');
+      expect(() => {
+        onDataCallback(toArrayBuffer(moreData), true);
+      }).not.toThrow(); // Should not throw because handleIncomingChunk checks aborted flag
     });
   });
 

--- a/src/http/core/request.ts
+++ b/src/http/core/request.ts
@@ -1,10 +1,12 @@
 import type { HttpRequest, HttpResponse } from 'uWebSockets.js';
-import { Readable } from 'stream';
+import { Readable, Transform } from 'stream';
+import * as zlib from 'zlib';
 import * as cookie from 'cookie';
 import * as signature from 'cookie-signature';
 import type * as busboy from 'busboy';
 import type { MultipartFieldHandler } from '../body/multipart-handler';
 import { MultipartFormHandler } from '../body/multipart-handler';
+import type { UwsResponse } from './response';
 
 /**
  * Buffer watermark for backpressure management
@@ -136,6 +138,12 @@ export class UwsRequest extends Readable {
   // Reference to response (for body parsing and streaming)
   private readonly uwsRes: HttpResponse;
 
+  // Reference to response wrapper (for sending 413 status on body size limit)
+  private responseWrapper?: UwsResponse;
+
+  // Decompression stream for Content-Encoding support
+  private decompressionStream?: Transform;
+
   // Readable stream state (Hybrid streaming implementation)
   private streamActivated = false;
   private bodyParserMode: 'awaiting' | 'buffering' | 'streaming' = 'awaiting';
@@ -221,6 +229,7 @@ export class UwsRequest extends Readable {
    * - 'streaming': Pushes to readable stream for pipe() or stream consumers
    *
    * Also enforces size limits, handles backpressure, and checks for aborted connections.
+   * Supports automatic decompression for gzip/deflate/brotli Content-Encoding.
    *
    * @param chunk - Incoming data chunk
    * @param isLast - Whether this is the last chunk
@@ -242,14 +251,56 @@ export class UwsRequest extends Readable {
     // Buffer.from(chunk) creates a view that shares memory, which becomes invalid
     // We must create an independent copy using new Uint8Array(chunk)
     const buffer = Buffer.from(new Uint8Array(chunk));
+
+    // If decompression stream exists, write to it instead of processing directly
+    if (this.decompressionStream) {
+      const canContinue = isLast
+        ? (this.decompressionStream.end(buffer), true)
+        : this.decompressionStream.write(buffer);
+
+      // Handle backpressure from decompression stream
+      if (!canContinue && !isLast) {
+        this.pause();
+        this.decompressionStream.once('drain', () => {
+          this.resume();
+        });
+      }
+      return;
+    }
+
+    // No decompression - process buffer directly
+    this.processDecompressedChunk(buffer, isLast, fastAbort);
+  }
+
+  /**
+   * Process a decompressed chunk (or raw chunk if no decompression)
+   *
+   * @param buffer - Decompressed buffer
+   * @param isLast - Whether this is the last chunk
+   * @param fastAbort - Whether to close connection immediately on size limit
+   * @private
+   */
+  private processDecompressedChunk(buffer: Buffer, isLast: boolean, fastAbort: boolean): void {
     this.totalReceivedBytes += buffer.length;
 
     // Enforce size limit
     if (this.maxBodySize > 0 && this.totalReceivedBytes > this.maxBodySize) {
-      // Size limit exceeded - mark as flushing and close connection
+      // Size limit exceeded - mark as flushing to stop processing chunks
       this.flushing = true;
       this.abortError = new Error('Body size limit exceeded');
-      this.uwsRes.close();
+
+      // Send 413 Payload Too Large response if response hasn't been initiated
+      if (this.responseWrapper && !this.responseWrapper.headersSent && !fastAbort) {
+        try {
+          this.responseWrapper.status(413).send();
+        } catch {
+          // If sending 413 fails (e.g., connection already closed), fall back to closing
+          this.uwsRes.close();
+        }
+      } else {
+        // Fast abort mode or response already initiated - close connection immediately
+        this.uwsRes.close();
+      }
 
       // Only emit error if not using fast abort (for proper error handling)
       if (!fastAbort) {
@@ -816,6 +867,121 @@ export class UwsRequest extends Readable {
   }
 
   /**
+   * Check if body size exceeds limit and handle accordingly
+   * @private
+   */
+  private handleBodySizeLimit(
+    contentLength: number,
+    maxBodySize: number,
+    fastAbort: boolean
+  ): boolean {
+    if (maxBodySize > 0 && contentLength > maxBodySize) {
+      this.abortError = new Error('Body size limit exceeded');
+      this.aborted = true;
+      this.doneReadingData = true;
+
+      if (this.responseWrapper && !this.responseWrapper.headersSent && !fastAbort) {
+        try {
+          this.responseWrapper.status(413).send();
+        } catch {
+          this.uwsRes.close();
+        }
+      } else {
+        this.uwsRes.close();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Create decompression stream based on Content-Encoding header
+   * @private
+   */
+  private createDecompressionStream(encoding: string): Transform | null | false {
+    switch (encoding) {
+      case 'gzip':
+        return zlib.createGunzip();
+      case 'deflate':
+        return zlib.createInflate();
+      case 'br':
+        return zlib.createBrotliDecompress();
+      case 'identity':
+        return null; // No decompression needed
+      default:
+        return false; // Unsupported encoding
+    }
+  }
+
+  /**
+   * Handle unsupported Content-Encoding
+   * @private
+   */
+  private handleUnsupportedEncoding(encoding: string, fastAbort: boolean): void {
+    this.abortError = new Error(`Unsupported content encoding: ${encoding}`);
+    this.aborted = true;
+    this.doneReadingData = true;
+
+    if (this.responseWrapper && !this.responseWrapper.headersSent && !fastAbort) {
+      try {
+        this.responseWrapper.status(415).send({
+          error: 'Unsupported Media Type',
+          message: `Content-Encoding '${encoding}' is not supported. Supported encodings: gzip, deflate, br, identity`,
+        });
+      } catch {
+        this.uwsRes.close();
+      }
+    } else {
+      this.uwsRes.close();
+    }
+  }
+
+  /**
+   * Set up decompression stream event handlers
+   * @private
+   */
+  private setupDecompressionHandlers(decompress: Transform, fastAbort: boolean): void {
+    this.decompressionStream = decompress;
+
+    decompress.on('data', (chunk: Buffer) => {
+      this.processDecompressedChunk(chunk, false, fastAbort);
+    });
+
+    decompress.on('end', () => {
+      this.doneReadingData = true;
+
+      // Signal EOF to streaming consumers
+      if (this.bodyParserMode === 'streaming') {
+        this.push(null);
+      }
+
+      this.emit('received', this.totalReceivedBytes);
+    });
+
+    decompress.on('error', (error: Error) => {
+      this.flushing = true;
+      this.aborted = true;
+      this.abortError = error;
+
+      if (this.responseWrapper && !this.responseWrapper.headersSent && !fastAbort) {
+        try {
+          this.responseWrapper.status(400).send({ error: 'Invalid compressed data' });
+        } catch {
+          this.uwsRes.close();
+        }
+      } else {
+        this.uwsRes.close();
+      }
+
+      if (!fastAbort && this.listenerCount('error') > 0) {
+        this.destroy(error);
+      } else {
+        this.destroy();
+      }
+    });
+  }
+
+  /**
    * Initialize body parser (called by platform adapter)
    *
    * This must be called synchronously during request handling setup,
@@ -837,10 +1003,9 @@ export class UwsRequest extends Readable {
     fastAbort = false,
     response: import('./response').UwsResponse
   ): void {
-    // Store size limit for enforcement
     this.maxBodySize = maxBodySize;
+    this.responseWrapper = response;
 
-    // Check if we expect a body based on content-length or transfer-encoding
     const contentLength = this.contentLength;
 
     // Check for chunked transfer encoding
@@ -850,38 +1015,47 @@ export class UwsRequest extends Readable {
       : (transferEncodingHeader ?? '');
     const hasChunkedBody = transferEncoding.toLowerCase().includes('chunked');
 
-    // Only skip body handling if:
-    // - contentLength is explicitly 0, OR
-    // - contentLength is undefined AND no chunked transfer encoding
+    // Skip body handling if no body expected
     if (contentLength === 0 || (contentLength === undefined && !hasChunkedBody)) {
-      // No body expected - keep doneReadingData as true
       return;
     }
 
-    // Check size limit before starting to receive data (only for known content-length)
-    if (maxBodySize > 0 && contentLength !== undefined && contentLength > maxBodySize) {
-      // Body exceeds limit - set error state and close connection
-      // Don't call destroy() here to avoid emitting error during construction
-      // Body methods will check aborted state via checkAborted() and throw
-      this.abortError = new Error('Body size limit exceeded');
-      this.aborted = true;
-      this.doneReadingData = true; // Mark as done to prevent waiting
-      this.uwsRes.close();
+    // Check size limit for known content-length
+    if (
+      contentLength !== undefined &&
+      this.handleBodySizeLimit(contentLength, maxBodySize, fastAbort)
+    ) {
       return;
     }
 
-    // We expect a body - set doneReadingData to false
     this.doneReadingData = false;
 
-    // Register abort handler through response multiplexing
-    // The response object provides _onAbort() which allows multiple handlers
-    // to be registered without overwriting each other (unlike direct uwsRes.onAborted())
+    // Handle Content-Encoding decompression
+    const contentEncodingHeader = this.get('content-encoding');
+    const contentEncoding = Array.isArray(contentEncodingHeader)
+      ? contentEncodingHeader.join(',')
+      : (contentEncodingHeader ?? '');
+
+    if (contentEncoding) {
+      const encoding = contentEncoding.toLowerCase().trim();
+      const decompress = this.createDecompressionStream(encoding);
+
+      if (decompress === false) {
+        this.handleUnsupportedEncoding(encoding, fastAbort);
+        return;
+      }
+
+      if (decompress) {
+        this.setupDecompressionHandlers(decompress, fastAbort);
+      }
+    }
+
+    // Register abort handler
     response._onAbort(() => {
       this.aborted = true;
       this.abortError = new Error('Connection aborted');
-      this.flushing = true; // Stop processing chunks
+      this.flushing = true;
 
-      // Only emit error if there are listeners to handle it
       if (this.listenerCount('error') > 0) {
         this.destroy(this.abortError);
       } else {
@@ -889,7 +1063,7 @@ export class UwsRequest extends Readable {
       }
     });
 
-    // Register onData callback for streaming infrastructure
+    // Register onData callback
     this.uwsRes.onData((chunk, isLast) => {
       this.handleIncomingChunk(chunk, isLast, fastAbort);
     });


### PR DESCRIPTION
- Request bodies with `Content-Encoding: gzip/deflate/br` are now automatically decompressed.
- When request body exceeds `maxBodySize`, it now returns proper HTTP 413 Payload Too Large response.

Fix #94 
Fix #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic decompression support for compressed request bodies.

* **Bug Fixes**
  * Improved error handling for unsupported compression formats and decompression stream failures with appropriate HTTP error responses.
  * Enhanced request body size validation and enforcement for better resource protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->