### PR TITLE
docs(body-parser): document flushBuffered exception behavior (#86)

### DIFF
--- a/src/http/body/body-parser.ts
+++ b/src/http/body/body-parser.ts
@@ -324,7 +324,19 @@ export class BodyParser {
   }
 
   /**
-   * Flush buffered chunks to the passthrough callback
+   * Flush buffered chunks to the passthrough callback.
+   *
+   * Exception handling: if `passthroughCallback` throws while iterating
+   * the captured chunk array, the exception propagates to the caller and
+   * any chunks that had not yet been delivered are dropped along with the
+   * captured array. The parser still resumes via the `finally` block, so
+   * the stream is not left paused, but the lost chunks are not retried.
+   *
+   * This is intentional. A throwing `passthroughCallback` indicates a
+   * programming error in user code; the contract is that the callback
+   * does not throw under normal operation. Mid-iteration data loss is
+   * preferable to silently swallowing exceptions or letting the parser
+   * sit in a stuck state because of buggy user code.
    */
   private flushBuffered(): void {
     if (this.bufferedChunks.length > 0) {
@@ -339,6 +351,8 @@ export class BodyParser {
 
           if (this.passthroughCallback) {
             // Chunk is already a Buffer, no need to convert
+            // If the callback throws here, the remaining `chunks[i+1..]`
+            // are dropped on purpose -- see the function-level docblock.
             this.passthroughCallback(chunks[i], isLast);
           }
         }


### PR DESCRIPTION
## Summary

Closes #86

Adds a function-level docblock to `flushBuffered` in `src/http/body/body-parser.ts` explaining the exception-handling contract for `passthroughCallback`:

- If the callback throws mid-iteration, the exception propagates to the caller.
- Any chunks in the captured array that had not yet been delivered are dropped along with the captured array (since `bufferedChunks` was already cleared).
- The parser still resumes via the `finally` block, so the stream is not left in a stuck paused state.

The docblock spells out why this is intentional rather than a bug: a throwing `passthroughCallback` indicates a programming error in user code, and the contract is that the callback does not throw under normal operation. Mid-iteration data loss is preferable to silently swallowing exceptions or leaving the parser paused because of buggy user code.

A one-line inline comment at the call site (`this.passthroughCallback(chunks[i], isLast);`) makes the drop behavior visible to a reader scanning the loop body.

## What changed

- Documentation only (15-line addition, no code change).
- `src/http/body/body-parser.ts`: function docblock on `flushBuffered` + one inline comment.

## Verification

- `npx tsc --noEmit -p tsconfig.json` clean.
- `npx prettier --check src/http/body/body-parser.ts` clean.
- `npx eslint src/http/body/body-parser.ts` clean.
- Body-parser tests still pass: `npx jest --testPathPatterns='src/http/body/'` -> 51 passed, 51 total.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for error handling behavior in the HTTP body parser to clarify exception propagation and connection state management during callback execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->