### PR TITLE
test(routing): compute content-length dynamically in middleware specs

### DIFF
--- a/src/http/routing/route-registry-middleware.spec.ts
+++ b/src/http/routing/route-registry-middleware.spec.ts
@@ -250,10 +250,15 @@ describe('RouteRegistry - Middleware Integration', () => {
         capturedBody = await req.body;
       });
 
+      // Compute content-length dynamically from the body bytes so the header
+      // value cannot drift away from the payload (issue #83).
+      const bodyData = JSON.stringify({ number: 5 });
+      const contentLength = String(Buffer.byteLength(bodyData));
+
       // Mock content-type header and content-length
       mockUwsReq.forEach = jest.fn((callback) => {
         callback('content-type', 'application/json');
-        callback('content-length', '13');
+        callback('content-length', contentLength);
       });
 
       // Create response with callback tracking
@@ -269,7 +274,6 @@ describe('RouteRegistry - Middleware Integration', () => {
       await new Promise((resolve) => setImmediate(resolve));
 
       // Simulate body data being received
-      const bodyData = JSON.stringify({ number: 5 });
       const arrayBuffer = toArrayBuffer(Buffer.from(bodyData));
 
       // Send the body data
@@ -392,10 +396,15 @@ describe('RouteRegistry - Middleware Integration', () => {
 
       const handler = jest.fn();
 
+      // Compute content-length dynamically from the body bytes so the header
+      // value cannot drift away from the payload (issue #83).
+      const bodyData = JSON.stringify({ name: 'John', age: 30 });
+      const contentLength = String(Buffer.byteLength(bodyData));
+
       // Mock content-type header and content-length
       mockUwsReq.forEach = jest.fn((callback) => {
         callback('content-type', 'application/json');
-        callback('content-length', '27');
+        callback('content-length', contentLength);
       });
 
       // Create response with callback tracking
@@ -418,7 +427,6 @@ describe('RouteRegistry - Middleware Integration', () => {
       await new Promise((resolve) => setImmediate(resolve));
 
       // Simulate body data
-      const bodyData = JSON.stringify({ name: 'John', age: 30 });
       const arrayBuffer = toArrayBuffer(Buffer.from(bodyData));
 
       callbacks.onData!(arrayBuffer, true);


### PR DESCRIPTION
## Summary

Closes #83.

Two tests in `src/http/routing/route-registry-middleware.spec.ts` hardcode
`content-length` header values that don't match the JSON payload they then
send through `onData`:

| Line | Header value | Actual JSON bytes |
| --- | --- | --- |
| 256 | `'13'` | `{"number":5}` -> 12 bytes |
| 398 | `'27'` | `{"name":"John","age":30}` -> 24 bytes |

The tests pass today because the implementation relies on uWS's `isLast`
flag rather than validating content-length, but the headers misrepresent
the HTTP behavior real `uWebSockets.js` performs (it reads
`content-length` and only fires `isLast=true` after exactly that many
bytes arrive).

## Implementation

The issue suggested computing the content-length dynamically from the
body, e.g. `String(Buffer.from(bodyData).length)`. I went with
`Buffer.byteLength(bodyData)` -- same result for the strings here,
slightly more idiomatic since we already have the string in hand.

For both tests:

1. Hoist the `bodyData` definition above the `mockUwsReq.forEach` setup.
2. Compute `contentLength = String(Buffer.byteLength(bodyData))`.
3. Pass `contentLength` into the `forEach` mock instead of a magic string.

The third middleware test in the file (around line 312) was already
following this pattern via `String(bodyBuffer.length)`. This change
brings the other two in line.

## Verification

```
npx jest src/http/routing/route-registry-middleware.spec.ts
# Test Suites: 1 passed, 1 total
# Tests:       18 passed, 18 total

npx eslint src/http/routing/route-registry-middleware.spec.ts   # clean
npx prettier --check src/http/routing/route-registry-middleware.spec.ts  # clean
```

## Notes

- Single test file, +12/-4. No production code touched.
- The body-and-header-agree-by-construction property the issue
  asks for is now structurally enforced: if a future change edits
  the JSON payload, the header value follows automatically.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to dynamically compute content-length values instead of hardcoded byte counts, improving test accuracy and reliability for HTTP request validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->