### PR TITLE
test(uws-platform): assert HEAD route registration on static-asset single-call tests

### DIFF
--- a/src/http/platform/uws-platform.adapter.spec.ts
+++ b/src/http/platform/uws-platform.adapter.spec.ts
@@ -534,15 +534,19 @@ describe('UwsPlatformAdapter', () => {
     it('should enable static assets and register catch-all route', () => {
       adapter.useStaticAssets('/public');
 
-      // Should register a GET route for /*
+      // Should register both GET and HEAD routes for /*
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/*', expect.any(Function));
     });
 
     it('should respect silent option and not log', () => {
       adapter.useStaticAssets('/public', { silent: true });
 
-      // Should still register the route
+      // Should still register both GET and HEAD routes
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/*', expect.any(Function));
     });
 
     it('should register static assets route when custom options provided', () => {
@@ -551,8 +555,10 @@ describe('UwsPlatformAdapter', () => {
         etag: false,
       });
 
-      // Should register the route
+      // Should register both GET and HEAD routes
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/*', expect.any(Function));
     });
 
     it('should register multiple static asset routes when called multiple times', () => {
@@ -572,22 +578,28 @@ describe('UwsPlatformAdapter', () => {
     it('should support prefix option for scoped static routes', () => {
       adapter.useStaticAssets('/public', { prefix: '/assets' });
 
-      // Should register route with prefix
+      // Should register both GET and HEAD routes with the prefix
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/assets/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/assets/*', expect.any(Function));
     });
 
     it('should normalize prefix by removing trailing slash', () => {
       adapter.useStaticAssets('/public', { prefix: '/assets/' });
 
-      // Should register route with normalized prefix (no trailing slash)
+      // Should register both GET and HEAD routes with normalized prefix (no trailing slash)
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/assets/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/assets/*', expect.any(Function));
     });
 
     it('should handle empty prefix by using default catch-all', () => {
       adapter.useStaticAssets('/public', { prefix: '' });
 
-      // Should register default catch-all route
+      // Should register both GET and HEAD default catch-all routes
+      expect(mockRegistry.register).toHaveBeenCalledTimes(2);
       expect(mockRegistry.register).toHaveBeenCalledWith('GET', '/*', expect.any(Function));
+      expect(mockRegistry.register).toHaveBeenCalledWith('HEAD', '/*', expect.any(Function));
     });
 
     it('should throw error for invalid path (non-string)', () => {


### PR DESCRIPTION
## Summary

The `useStaticAssets()` implementation registers both GET and HEAD routes per call (`uws-platform.adapter.ts:822-823`), but six of the seven success-path tests in the `static assets` describe block only asserted the GET registration. The one multi-call test already verifies the GET+HEAD = 4 shape; the single-call tests were the gap the issue calls out.

Closes #82

## Why this matters

If a refactor accidentally drops the `this.head(routePattern, ...)` line, today's tests would still pass because none of the single-call cases check for the HEAD registration. That's the bug class issue #82 surfaces. Strengthening the assertions to match the multi-call test's pattern closes the loop and keeps the suite a true regression net for static-asset routing.

## Change

`src/http/platform/uws-platform.adapter.spec.ts` only. Six single-call success-path tests now assert `toHaveBeenCalledTimes(2)` plus the corresponding `HEAD` registration alongside the existing `GET` assertion: `should enable static assets and register catch-all route`, `should respect silent option and not log`, `should register static assets route when custom options provided`, `should support prefix option for scoped static routes`, `should normalize prefix by removing trailing slash`, `should handle empty prefix by using default catch-all`.

Untouched: the multi-call `should register multiple static asset routes when called multiple times` (already correct - asserts 4 registrations) and the two error-path tests for invalid input (no registrations to assert).

## Verification

`npm test -- --testPathPatterns=uws-platform` -> `Test Suites: 1 passed, 1 total / Tests: 66 passed, 66 total`. No production code touched.

## Risk

None - tests-only strengthening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated static assets test suite to verify both GET and HEAD route registration for static asset endpoints, ensuring proper HTTP method support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->