### PR TITLE
fix: support HTTP middleware metadata instances

### DIFF
--- a/src/http/routing/index.ts
+++ b/src/http/routing/index.ts
@@ -1,2 +1,9 @@
 export { RouteRegistry } from './route-registry';
-export type { RouteHandler, RouteMetadata, RouteInfo } from './route-registry';
+export type {
+  ExceptionFilterProvider,
+  GuardProvider,
+  PipeProvider,
+  RouteHandler,
+  RouteInfo,
+  RouteMetadata,
+} from './route-registry';

--- a/src/http/routing/route-registry-middleware.spec.ts
+++ b/src/http/routing/route-registry-middleware.spec.ts
@@ -60,6 +60,20 @@ describe('RouteRegistry - Middleware Integration', () => {
       expect(executionOrder).toEqual(['guard', 'handler']);
     });
 
+    it('should accept guard instances from route metadata', async () => {
+      const guard: CanActivate = {
+        canActivate: jest.fn().mockReturnValue(true),
+      };
+      const handler = jest.fn();
+
+      registry.register('GET', '/instance-guard', handler, { guards: [guard] });
+
+      await registeredRoutes.get('GET:/instance-guard')?.handler!(mockUwsRes, mockUwsReq);
+
+      expect(guard.canActivate).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalled();
+    });
+
     it('should deny access when guard returns false', async () => {
       class DenyGuard implements CanActivate {
         async canActivate(): Promise<boolean> {
@@ -286,6 +300,45 @@ describe('RouteRegistry - Middleware Integration', () => {
       expect(capturedBody).toEqual({ number: 10 });
     });
 
+    it('should accept pipe instances from route metadata', async () => {
+      const pipe: PipeTransform = {
+        transform: jest.fn((value) =>
+          typeof value === 'object' && value !== null && 'name' in value
+            ? { ...value, name: 'Ada' }
+            : value
+        ),
+      };
+
+      let capturedBody: any;
+      const handler = jest.fn(async (req) => {
+        capturedBody = await req.body;
+      });
+      const bodyData = JSON.stringify({ name: 'Grace' });
+      const bodyBuffer = Buffer.from(bodyData);
+
+      mockUwsReq.forEach = jest.fn((callback) => {
+        callback('content-type', 'application/json');
+        callback('content-length', String(bodyBuffer.length));
+      });
+
+      const { mockRes, callbacks } = createMockUwsResponse();
+      mockUwsRes = mockRes;
+
+      registry.register('POST', '/instance-pipe', handler, { pipes: [pipe] });
+
+      const handlerPromise = registeredRoutes.get('POST:/instance-pipe')?.handler!(
+        mockUwsRes,
+        mockUwsReq
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+      callbacks.onData!(toArrayBuffer(bodyBuffer), true);
+      await handlerPromise;
+
+      expect(pipe.transform).toHaveBeenCalled();
+      expect(capturedBody).toEqual({ name: 'Ada' });
+    });
+
     it('should execute multiple pipes in order', async () => {
       const executionOrder: string[] = [];
 
@@ -465,6 +518,25 @@ describe('RouteRegistry - Middleware Integration', () => {
 
       expect(filterExecuted).toHaveBeenCalledWith('Test error');
       expect(mockUwsRes.writeStatus).toHaveBeenCalledWith('400 Bad Request');
+    });
+
+    it('should accept exception filter instances from route metadata', async () => {
+      const filter: ExceptionFilter = {
+        catch: jest.fn((_exception: Error, host: any) => {
+          const response = host.switchToHttp().getResponse();
+          response.status(418).send({ error: 'handled by instance' });
+        }),
+      };
+      const handler = jest.fn(() => {
+        throw new Error('Test error');
+      });
+
+      registry.register('GET', '/instance-filter', handler, { filters: [filter] });
+
+      await registeredRoutes.get('GET:/instance-filter')?.handler!(mockUwsRes, mockUwsReq);
+
+      expect(filter.catch).toHaveBeenCalled();
+      expect(mockUwsRes.writeStatus).toHaveBeenCalledWith("418 I'm a Teapot");
     });
 
     it('should use default error handling when no filters provided', async () => {

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -23,6 +23,9 @@ import { ModuleRef, DefaultModuleRef } from '../../shared/di';
  * Route handler function type
  */
 export type RouteHandler = (req: UwsRequest, res: UwsResponse) => void | Promise<void>;
+export type GuardProvider = Type<CanActivate> | CanActivate;
+export type PipeProvider = Type<PipeTransform> | PipeTransform;
+export type ExceptionFilterProvider = Type<ExceptionFilter> | ExceptionFilter;
 
 /**
  * Route metadata for middleware execution
@@ -36,17 +39,17 @@ export interface RouteMetadata {
   /**
    * Guards to execute before handler
    */
-  guards?: Type<CanActivate>[];
+  guards?: GuardProvider[];
 
   /**
    * Pipes to execute on request body
    */
-  pipes?: Type<PipeTransform>[];
+  pipes?: PipeProvider[];
 
   /**
    * Exception filters to handle errors
    */
-  filters?: Type<ExceptionFilter>[];
+  filters?: ExceptionFilterProvider[];
 
   /**
    * Optional argument metadata for pipe transformation
@@ -497,12 +500,13 @@ export class RouteRegistry {
    */
   private async executeGuards(
     context: HttpExecutionContext,
-    guards: Type<CanActivate>[]
+    guards: GuardProvider[]
   ): Promise<boolean> {
     for (const GuardType of guards) {
+      const guardName = this.getMiddlewareName(GuardType);
+
       try {
-        // Resolve guard from DI container (or instantiate if no DI)
-        const guard = this.moduleRef.get(GuardType);
+        const guard = this.resolveGuard(GuardType);
 
         // Execute guard - cast to ExecutionContext for compatibility
         // Guards can return boolean, Promise<boolean>, or Observable<boolean>
@@ -517,7 +521,7 @@ export class RouteRegistry {
       } catch (error) {
         // Guard threw an error - propagate to exception filters
         // This allows HttpException status codes to be preserved
-        this.logger.error(`Guard ${GuardType.name} threw an error:`, error);
+        this.logger.error(`Guard ${guardName} threw an error:`, error);
         throw error;
       }
     }
@@ -534,7 +538,7 @@ export class RouteRegistry {
    * @returns Transformed value
    */
   private async executePipes(
-    pipes: Type<PipeTransform>[],
+    pipes: PipeProvider[],
     value: unknown,
     argMetadata?: ArgumentMetadata
   ): Promise<unknown> {
@@ -548,9 +552,10 @@ export class RouteRegistry {
     };
 
     for (const PipeType of pipes) {
+      const pipeName = this.getMiddlewareName(PipeType);
+
       try {
-        // Resolve pipe from DI container (or instantiate if no DI)
-        const pipe = this.moduleRef.get(PipeType);
+        const pipe = this.resolvePipe(PipeType);
 
         // Execute pipe - pipes can return value, Promise<value>, or Observable<value>
         const pipeResult = pipe.transform(transformedValue, metadata);
@@ -559,7 +564,7 @@ export class RouteRegistry {
           : await pipeResult;
       } catch (error) {
         // Pipe threw an error - propagate to exception filters
-        this.logger.error(`Pipe ${PipeType.name} threw an error:`, error);
+        this.logger.error(`Pipe ${pipeName} threw an error:`, error);
         throw error;
       }
     }
@@ -592,9 +597,10 @@ export class RouteRegistry {
       const filterErrors: Array<{ filterName: string; error: Error }> = [];
 
       for (const FilterType of metadata.filters) {
+        const filterName = this.getMiddlewareName(FilterType);
+
         try {
-          // Resolve filter from DI container (or instantiate if no DI)
-          const filter = this.moduleRef.get(FilterType);
+          const filter = this.resolveFilter(FilterType);
 
           // Create arguments host
           const host = this.createArgumentsHost(context);
@@ -616,10 +622,10 @@ export class RouteRegistry {
         } catch (filterError) {
           // Accumulate filter errors for debugging
           filterErrors.push({
-            filterName: FilterType.name,
+            filterName,
             error: filterError as Error,
           });
-          this.logger.error(`Exception filter ${FilterType.name} threw an error:`, filterError);
+          this.logger.error(`Exception filter ${filterName} threw an error:`, filterError);
         }
       }
 
@@ -657,6 +663,22 @@ export class RouteRegistry {
         });
       }
     }
+  }
+
+  private resolveGuard(guard: GuardProvider): CanActivate {
+    return typeof guard === 'function' ? this.moduleRef.get(guard) : guard;
+  }
+
+  private resolvePipe(pipe: PipeProvider): PipeTransform {
+    return typeof pipe === 'function' ? this.moduleRef.get(pipe) : pipe;
+  }
+
+  private resolveFilter(filter: ExceptionFilterProvider): ExceptionFilter {
+    return typeof filter === 'function' ? this.moduleRef.get(filter) : filter;
+  }
+
+  private getMiddlewareName(middleware: Type<unknown> | object): string {
+    return typeof middleware === 'function' ? middleware.name : middleware.constructor.name;
   }
 
   /**


### PR DESCRIPTION
## Summary
- allow HTTP route metadata guards, pipes, and exception filters to be class providers or pre-built instances
- resolve instance metadata directly before falling back to `ModuleRef` for class providers
- add regression coverage for guard, pipe, and exception filter instances

Fixes #128

## Verification
- `npm test -- --runInBand src/http/routing/route-registry-middleware.spec.ts`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npx eslint src/http/routing/route-registry.ts src/http/routing/route-registry-middleware.spec.ts`
- `npx prettier --check src/http/routing/route-registry.ts src/http/routing/route-registry-middleware.spec.ts`
- `git diff --check -- src/http/routing/route-registry.ts src/http/routing/route-registry-middleware.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route middleware configuration now accepts both class constructors and pre-instantiated objects for guards, pipes, and exception filters, enabling greater flexibility in middleware setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->