### PR TITLE
fix(response): make send() a no-op when response already finished (#134)

### DIFF
--- a/src/http/core/response.spec.ts
+++ b/src/http/core/response.spec.ts
@@ -536,9 +536,10 @@ describe('UwsResponse', () => {
       expect(mockUwsRes.writeHeader).toHaveBeenCalledWith('set-cookie', 'user=vikram');
     });
 
-    it('should throw if already sent', () => {
+    it('should be a no-op if already sent', () => {
       res.send('First');
-      expect(() => res.send('Second')).toThrow('Response already sent');
+      expect(() => res.send('Second')).not.toThrow();
+      expect(mockUwsRes.end).toHaveBeenCalledTimes(1);
     });
 
     it('should not throw if aborted', () => {

--- a/src/http/core/response.ts
+++ b/src/http/core/response.ts
@@ -1268,7 +1268,7 @@ export class UwsResponse extends Writable {
     }
 
     if (this.finished) {
-      throw new Error('Response already sent');
+      return;
     }
 
     if (this.sending) {


### PR DESCRIPTION
Fixes #134.

When a handler sends a response then throws, NestJS's exception filter calls `adapter.end(response)` to gracefully close the response. This delegated to `UwsResponse.send()`, which threw `Error: Response already sent` because `this.finished` was already `true`. The throw was logged as a spurious "Unhandled route error" even though the client had already received their response.

## Change

In `src/http/core/response.ts`, changed the guard from a throw to a silent return — matching Express and Fastify behavior:

```ts
if (this.finished) {
  return;
}
```

## Testing

Added `test/http/response-send-after-finished.e2e.spec.ts` with two tests:
- Response is still delivered correctly to the client
- "Response already sent" is no longer logged when a handler throws after `send()`

Both pass. Pre-existing failures in `static-file-serving.e2e.spec.ts` were observed on clean `main` and are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Response handler now silently ignores duplicate send() calls instead of throwing an error, allowing graceful handling of redundant requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/135)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->