### PR TITLE
refactor: replace fragile ModuleRef detection

### DIFF
--- a/src/websocket/adapter/uws.adapter.ts
+++ b/src/websocket/adapter/uws.adapter.ts
@@ -15,7 +15,7 @@ import { HandlerExecutor } from '../routing/handler-executor';
 import { RoomManager } from '../rooms/room-manager';
 import { UwsSocketImpl } from '../core/socket';
 import { LifecycleHooksManager } from './lifecycle-hooks';
-import { NestJsModuleRef, type ModuleRef } from '../../shared/di';
+import { DefaultModuleRef, NestJsModuleRef, type ModuleRef } from '../../shared/di';
 
 /**
  * Extended WebSocket with client data
@@ -173,9 +173,8 @@ export class UwsAdapter implements WebSocketAdapter {
     // Normalize null to undefined for consistent "no DI" representation
     const rawModuleRef = options?.moduleRef ?? undefined;
     let moduleRef: ModuleRef | undefined = rawModuleRef;
-    if (rawModuleRef && !('instances' in rawModuleRef)) {
-      // It's a NestJS ModuleRef (doesn't have our DefaultModuleRef's instances property)
-      // Wrap it with our adapter
+    if (rawModuleRef && !(rawModuleRef instanceof DefaultModuleRef)) {
+      // External Nestjs ModuleRef provided, wrap it with our adapter.
       moduleRef = NestJsModuleRef.create(rawModuleRef as unknown as NestModuleRef);
     }
     this.handlerExecutor = new HandlerExecutor({ moduleRef });


### PR DESCRIPTION
Fixes #90

## Summary

Replaces the fragile internal property check:

```ts
'instances' in rawModuleRef
```

with an explicit:

```ts
rawModuleRef instanceof DefaultModuleRef
```

check when distinguishing between the internal `DefaultModuleRef` and external NestJS `ModuleRef` implementations.

## Why

The previous approach depended on an internal implementation detail (`instances` property), which is more fragile and less explicit.

Using `instanceof DefaultModuleRef` makes the intent clearer and improves maintainability without changing existing behavior.

## Validation

- Ran websocket test suite successfully
- Applied prettier formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved WebSocket adapter's handling of externally-supplied module references, enhancing the reliability and consistency of dependency injection support for guards, pipes, and filters. The adapter now uses more robust detection to identify module reference types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/143)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->