### PR TITLE
fix(http): resolve instance handling #128 and misleading jsDOC issue

### DIFF
--- a/docs/http/Routing.md
+++ b/docs/http/Routing.md
@@ -30,6 +30,31 @@ uWestJS provides full routing support with NestJS decorators:
 
 ---
 
+## Usage Models
+
+uWestJS supports two distinct routing usage models for HTTP, similar to its WebSocket implementation:
+
+### 1. NestJS Controller Pipeline (Standard)
+This is the standard approach using NestJS decorators (`@Controller()`, `@Get()`, etc.). The NestJS framework automatically parses your classes, configures the route registry, and wraps your methods in its internal execution pipeline. This is the recommended approach for almost all applications.
+
+### 2. Direct Registry Registration (Advanced)
+For advanced use cases requiring programmatic route creation outside of NestJS controllers, uWestJS provides an adapter API via `UwsPlatformAdapter.addRoute()`. This allows you to manually register routes while still executing standard NestJS guards, pipes, and filters.
+
+```typescript
+// Advanced usage: Direct registration
+const adapter = app.getHttpAdapter() as UwsPlatformAdapter;
+
+adapter.addRoute('GET', '/health', (req, res) => {
+  res.send({ status: 'ok' });
+}, {
+  guards: [CustomAuthGuard],
+  pipes: [CustomValidationPipe],
+  filters: [CustomExceptionFilter]
+});
+```
+
+---
+
 ## Route Registration
 
 ### Basic Routes

--- a/src/http/platform/uws-platform.adapter.ts
+++ b/src/http/platform/uws-platform.adapter.ts
@@ -417,17 +417,25 @@ export class UwsPlatformAdapter extends AbstractHttpAdapter {
   }
 
   /**
-   * Register a route with metadata (guards, pipes, filters)
+   * Add a route directly with middleware metadata (advanced usage).
    *
-   * Used by NestJS to register routes with their associated middleware metadata.
-   * The metadata is passed to the route registry which executes the middleware pipeline.
+   * This is NOT called by NestJS. For standard NestJS controllers,
+   * use @Controller() and @Get() / @Post() etc. - NestJS handles
+   * guards/pipes/filters automatically.
+   *
+   * Use this method when you need direct control over route registration
+   * outside of NestJS's standard controller pipeline. The metadata is
+   * executed by the internal RouteRegistry pipeline.
+   *
+   * @example
+   * ```typescript
+   * adapter.addRoute('GET', '/health', handler, {
+   *   guards: [AuthGuard],
+   *   filters: [HttpExceptionFilter],
+   * });
+   * ```
    */
-  registerRouteWithMetadata(
-    method: string,
-    path: string,
-    handler: Function,
-    metadata: RouteMetadata
-  ): void {
+  addRoute(method: string, path: string, handler: Function, metadata?: RouteMetadata): void {
     this.routeRegistry.register(method.toUpperCase(), path, handler as any, metadata);
   }
 

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -677,8 +677,12 @@ export class RouteRegistry {
     return typeof filter === 'function' ? this.moduleRef.get(filter) : filter;
   }
 
-  private getMiddlewareName(middleware: Type<unknown> | object): string {
-    return typeof middleware === 'function' ? middleware.name : middleware.constructor.name;
+  private getMiddlewareName(middleware: Type<unknown> | Record<string, any>): string {
+    if (!middleware) return 'UnknownMiddleware';
+    if (typeof middleware === 'function') {
+      return middleware.name;
+    }
+    return middleware.constructor?.name || 'AnonymousMiddleware';
   }
 
   /**


### PR DESCRIPTION
Fixes #129 
- Fixed instance handling bug in `RouteRegistry.getMiddlewareName` to support passing plain object instances in route metadata without throwing errors.
- Renamed `registerRouteWithMetadata` to `addRoute` to signify programmatic usage outside of the NestJS standard pipeline.
- Updated the JSDoc for `addRoute` to clearly identify it as an advanced/manual API.
- Documented the dual usage model (NestJS Controller Pipeline vs Direct Registry Registration) in the HTTP Routing documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Advanced HTTP routing method now available for custom, non-standard route registration with metadata support.

* **Bug Fixes**
  * Improved middleware handling to gracefully manage undefined or falsy configurations.

* **Documentation**
  * Added "Usage Models" section to routing documentation with detailed examples and implementation patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->