### PR TITLE
fix: avoid duplicate content-length on empty responses

### DIFF
--- a/src/http/core/response.spec.ts
+++ b/src/http/core/response.spec.ts
@@ -512,6 +512,14 @@ describe('UwsResponse', () => {
       expect(mockUwsRes.end).toHaveBeenCalledWith();
     });
 
+    it('should end without body when an empty response has content-length', () => {
+      res.setHeader('content-length', '1024').send();
+
+      expect(mockUwsRes.writeHeader).not.toHaveBeenCalledWith('content-length', '1024');
+      expect(mockUwsRes.endWithoutBody).toHaveBeenCalledWith(1024);
+      expect(mockUwsRes.end).not.toHaveBeenCalled();
+    });
+
     it('should use custom status code', () => {
       res.status(404).send('Not Found');
       expect(mockUwsRes.writeStatus).toHaveBeenCalledWith('404 Not Found');

--- a/src/http/core/response.ts
+++ b/src/http/core/response.ts
@@ -1349,11 +1349,7 @@ export class UwsResponse extends Writable {
 
             if (retryFlushed) {
               // Successfully flushed, now send the final body
-              if (body !== undefined) {
-                this.uwsRes.end(body);
-              } else {
-                this.uwsRes.end();
-              }
+              this.endResponse(body);
 
               this._finishSend();
 
@@ -1365,11 +1361,7 @@ export class UwsResponse extends Writable {
           });
         } else {
           // No backpressure, send immediately
-          if (body !== undefined) {
-            this.uwsRes.end(body);
-          } else {
-            this.uwsRes.end();
-          }
+          this.endResponse(body);
 
           this._finishSend();
         }
@@ -1395,6 +1387,20 @@ export class UwsResponse extends Writable {
     }
 
     this.emit('finish');
+  }
+
+  private endResponse(body: string | Buffer | undefined): void {
+    if (body !== undefined) {
+      this.uwsRes.end(body);
+      return;
+    }
+
+    if (this.contentLengthTotal !== undefined) {
+      this.uwsRes.endWithoutBody(this.contentLengthTotal);
+      return;
+    }
+
+    this.uwsRes.end();
   }
 
   /**

--- a/src/http/test-helpers.ts
+++ b/src/http/test-helpers.ts
@@ -154,6 +154,7 @@ export function createMockUwsResponse(options: MockUwsResponseOptions = {}): {
     writeHeader: jest.fn().mockReturnThis(),
     write: jest.fn(() => writeSuccess),
     end: jest.fn(),
+    endWithoutBody: jest.fn(),
     getWriteOffset: jest.fn(() => 0),
     tryEnd: jest.fn(() => [writeSuccess, tryEndComplete]),
     pause: jest.fn(),


### PR DESCRIPTION
Closes #147

## Summary
- route empty responses with a tracked numeric content-length through `endWithoutBody()`
- reuse the same ending helper for the immediate and backpressure retry paths
- add a regression test for `send()` with a custom `content-length` and no body

## Verification
- `npm test -- --runTestsByPath src/http/core/response.spec.ts`
- `npm run build`
- `npm run lint -- --quiet`
- `git diff --check`