### PR TITLE
fix: suppress response body for HEAD requests

### DIFF
--- a/src/http/core/response.spec.ts
+++ b/src/http/core/response.spec.ts
@@ -565,6 +565,41 @@ describe('UwsResponse', () => {
     });
   });
 
+  describe('HEAD request handling', () => {
+    it('should suppress body for HEAD request with content-length', () => {
+      res = createResponse();
+      const mockReq = { method: 'HEAD' } as any;
+      res.bindRequest(mockReq);
+
+      res.setHeader('content-length', '1024').send('Hello');
+
+      expect(mockUwsRes.endWithoutBody).toHaveBeenCalledWith(1024);
+      expect(mockUwsRes.end).not.toHaveBeenCalled();
+    });
+
+    it('should suppress body for HEAD request without content-length', () => {
+      res = createResponse();
+      const mockReq = { method: 'HEAD' } as any;
+      res.bindRequest(mockReq);
+
+      res.send('Hello');
+
+      expect(mockUwsRes.end).toHaveBeenCalledWith();
+      expect(mockUwsRes.endWithoutBody).not.toHaveBeenCalled();
+    });
+
+    it('should send body normally for GET request', () => {
+      res = createResponse();
+      const mockReq = { method: 'GET' } as any;
+      res.bindRequest(mockReq);
+
+      res.send('Hello');
+
+      expect(mockUwsRes.end).toHaveBeenCalledWith('Hello');
+      expect(mockUwsRes.endWithoutBody).not.toHaveBeenCalled();
+    });
+  });
+
   describe('json()', () => {
     beforeEach(() => {
       res = createResponse();

--- a/src/http/core/response.ts
+++ b/src/http/core/response.ts
@@ -1390,6 +1390,15 @@ export class UwsResponse extends Writable {
   }
 
   private endResponse(body: string | Buffer | undefined): void {
+    // HEAD responses must have identical headers to GET but no body (RFC 9110 §9.3.2)
+    if (this.req?.method === 'HEAD') {
+      if (this.contentLengthTotal !== undefined) {
+        this.uwsRes.endWithoutBody(this.contentLengthTotal);
+      } else {
+        this.uwsRes.end();
+      }
+      return;
+    }
     if (body !== undefined) {
       this.uwsRes.end(body);
       return;


### PR DESCRIPTION
## Summary
HEAD responses must have identical headers to GET but no body (RFC 9110 §9.3.2). uWS is low-level and doesn't strip bodies for HEAD automatically.

## Changes
- `src/http/core/response.ts`: In `endResponse()`, check `this.req?.getMethod() === 'head'` and call `endWithoutBody()` or `end()` without body when method is HEAD.

Fixes #151