### PR TITLE
test(request): verify empty-body json() cache on the same request (#80)

### DIFF
--- a/src/http/core/request.spec.ts
+++ b/src/http/core/request.spec.ts
@@ -448,22 +448,15 @@ describe('UwsRequest', () => {
         );
       });
 
-      it('should optimize empty bodies by using the exact same memory reference', async () => {
-        const req1 = new UwsRequest(mockUwsReq, mockUwsRes);
-        const req2 = new UwsRequest(mockUwsReq, mockUwsRes);
-
+      it('should cache empty body parse result across repeated json() calls', async () => {
         mockUwsReq.getMethod.mockReturnValue('GET');
-        const mockResponse1 = createMockResponse();
-        req1._initBodyParser(1024, false, mockResponse1 as any);
-        const mockResponse2 = createMockResponse();
-        req2._initBodyParser(1024, false, mockResponse2 as any);
+        const req = new UwsRequest(mockUwsReq, mockUwsRes);
+        const mockResponse = createMockResponse();
+        req._initBodyParser(1024, false, mockResponse as any);
 
-        onDataCallback(toArrayBuffer(Buffer.from('')), true);
+        const res1 = await req.json();
+        const res2 = await req.json();
 
-        const res1 = await req1.json();
-        const res2 = await req2.json();
-
-        // Referential equality proves zero new objects were allocated
         expect(res1).toBe(res2);
         expect(Object.isFrozen(res1)).toBe(true);
       });


### PR DESCRIPTION
## Summary

Fixes #80. The test "should optimize empty bodies by using the exact same memory reference" set up two separate `UwsRequest` instances and then invoked the module-level `onDataCallback`, which is overwritten by every call to `_initBodyParser`. Only the second request had a live callback wired up, so the test wasn't actually exercising the optimization it claimed to.

This rewrite uses a single request and calls `json()` twice, which is the behavior the issue suggests testing: the cache returns the same frozen sentinel on repeat calls. The empty-body path resolves through the cached `EMPTY_FROZEN_OBJECT`, so no `onDataCallback` invocation is needed.

## What changed

- `src/http/core/request.spec.ts`: replaced the dual-request setup with a single-request test that asserts both repeat `json()` calls return the same frozen object.

## Verification

```
npx jest src/http/core/request.spec.ts
# 103 tests pass
```

Linter passes locally.
