### PR TITLE
fix(#150): auto-register HEAD route for GET routes

### DIFF
--- a/src/http/core/response.ts
+++ b/src/http/core/response.ts
@@ -1291,6 +1291,11 @@ export class UwsResponse extends Writable {
       finalBody = String(body);
     }
 
+    // RFC 9110 §9.3.2: HEAD responses must have identical headers to GET but no body.
+    if (this.req?.method === 'HEAD') {
+      finalBody = undefined;
+    }
+
     this.sending = true;
 
     // Apply compression if configured and body is present

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -245,6 +245,19 @@ export class RouteRegistry {
       metadata,
     });
 
+    // Auto-register HEAD route for GET routes (RFC 9110 §9.3.2)
+    if (normalizedMethod === 'GET') {
+      this.routes.set(`HEAD:${path}`, {
+        method: 'HEAD',
+        path,
+        uwsPath,
+        pattern,
+        paramNames,
+        isComplex,
+        handler,
+        metadata,
+      });
+    }
     // Get the uWS method function
     const uwsMethodFn = this.uwsApp[uwsMethod as keyof uWS.TemplatedApp] as any;
 


### PR DESCRIPTION
## Fix #150\nAuto-register HEAD route when GET route is registered.\n\n## Fix #151\nSuppress response body in `send()` when request method is HEAD (RFC 9110 §9.3.2).