### PR TITLE
Make tests explicit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Check eslint
         run: npm run lint
       
-      - name: Run tests
-        run: npm test
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run integration tests
+        run: npm run test:integration
       
       - name: Build package
         run: npm run build


### PR DESCRIPTION
Fixes #158.

This change makes CI output easier to diagnose by separating unit and integration test stages explicitly while continuing to use the existing npm scripts.

Changes:

* replace `npm test` with explicit `npm run test:unit`
* add separate `npm run test:integration` CI step

Validation:

* npm ci --cache .npm-cache --no-audit --no-fund
* npm run test:integration
* npm run format:check
* git diff --check

Notes:

* `npm run test:unit` currently has existing unrelated local failures in StaticFileHandler specs (`403` responses instead of expected static file responses).
* No application/runtime code was changed, only `.github/workflows/ci.yml`.