### PR TITLE
Fix: `_write()` chunked mode defers callback when backpressure is active

### DIFF
--- a/src/http/core/response.spec.ts
+++ b/src/http/core/response.spec.ts
@@ -953,6 +953,62 @@ describe('UwsResponse', () => {
     });
   });
 
+  describe('_write() backpressure callback deferral', () => {
+    beforeEach(() => {
+      res = createResponse();
+    });
+
+    it('should defer _write() callback when backpressure is detected', () => {
+      (mockUwsRes.write as jest.Mock).mockReturnValue(false);
+
+      const callback = jest.fn();
+      (res as any)['_write']('chunk', 'utf8', callback);
+
+      expect(mockUwsRes.write).toHaveBeenCalledTimes(1);
+      expect(callback).not.toHaveBeenCalled();
+      expect((res as any)['flushBackpressure']).toBe(true);
+
+      // Simulate drain
+      (mockUwsRes.write as jest.Mock).mockReturnValue(true);
+      callbacks.onWritable!();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith();
+      expect((res as any)['flushBackpressure']).toBe(false);
+    });
+
+    it('should invoke _write() callback with error on abort during backpressure', () => {
+      (mockUwsRes.write as jest.Mock).mockReturnValue(false);
+
+      // Register abort handler so callbacks.onAborted is available
+      res._onAbort(() => {});
+
+      const callback = jest.fn();
+      (res as any)['_write']('chunk', 'utf8', callback);
+
+      expect(callback).not.toHaveBeenCalled();
+
+      // Simulate abort
+      callbacks.onAborted!();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+      expect((res as any)['flushBackpressure']).toBe(false);
+    });
+
+    it('should call _write() callback immediately when no backpressure', () => {
+      (mockUwsRes.write as jest.Mock).mockReturnValue(true);
+
+      const callback = jest.fn();
+      (res as any)['_write']('chunk', 'utf8', callback);
+
+      expect(mockUwsRes.write).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith();
+      expect((res as any)['flushBackpressure']).toBe(false);
+    });
+  });
+
   // Helper to create a proper Readable stream for manual read() testing
   const createManualReadable = (chunks: Buffer[]) => {
     const remaining = [...chunks];

--- a/src/http/core/response.ts
+++ b/src/http/core/response.ts
@@ -88,6 +88,10 @@ export class UwsResponse extends Writable {
   private abortCallbacks: Array<() => void> = [];
   private abortHandlerRegistered = false;
 
+  // Backpressure tracking for chunked _write() callback deferral
+  private flushBackpressure = false;
+  private pendingDrainCallback?: (error?: Error | null) => void;
+
   // Compression support
   private req?: UwsRequest;
   private compressionHandler?: CompressionHandler;
@@ -153,6 +157,10 @@ export class UwsResponse extends Writable {
           callback(new Error('Connection aborted'));
         }
 
+        // Clear backpressure state and invoke pending drain callback
+        this.flushBackpressure = false;
+        this._invokeDrainCallback(new Error('Connection aborted'));
+
         // Emit 'close' event for Writable stream compatibility
         this.emit('close');
 
@@ -165,6 +173,22 @@ export class UwsResponse extends Writable {
           }
         }
       });
+    }
+  }
+
+  /**
+   * Invoke pending drain callback and clear it.
+   * Used to resume Writable stream pumping after backpressure clears.
+   */
+  private _invokeDrainCallback(error?: Error | null): void {
+    if (this.pendingDrainCallback) {
+      const cb = this.pendingDrainCallback;
+      this.pendingDrainCallback = undefined;
+      if (error) {
+        cb(error);
+      } else {
+        cb();
+      }
     }
   }
 
@@ -230,7 +254,11 @@ export class UwsResponse extends Writable {
     } else {
       // Chunked mode: use writeChunk() batching for fewer syscalls
       this.writeChunk(chunk, encoding);
-      callback();
+      if (this.flushBackpressure) {
+        this.pendingDrainCallback = callback;
+      } else {
+        callback();
+      }
     }
   }
 
@@ -759,15 +787,26 @@ export class UwsResponse extends Writable {
 
         // If backpressure detected, schedule retry via onWritable
         if (!writeResult && !this.finished && !this.aborted) {
+          this.flushBackpressure = true;
           this.uwsRes.onWritable(() => {
             // Check if connection is still active
             if (this.finished || this.aborted) {
+              this.flushBackpressure = false;
+              this._invokeDrainCallback(new Error('Connection aborted'));
               return true; // Remove handler
             }
 
             // Retry flushing pending chunks
-            return this.flushChunks();
+            const flushed = this.flushChunks();
+            if (flushed) {
+              this.flushBackpressure = false;
+              this._invokeDrainCallback();
+            }
+            return flushed;
           });
+        } else if (writeResult) {
+          this.flushBackpressure = false;
+          this._invokeDrainCallback();
         }
       } else if (!this.flushTimeout) {
         // Schedule flush after timeout
@@ -775,7 +814,11 @@ export class UwsResponse extends Writable {
           this.flushTimeout = undefined;
           if (!this.finished && !this.aborted) {
             this.atomic(() => {
-              this.flushChunks();
+              const flushed = this.flushChunks();
+              if (flushed) {
+                this.flushBackpressure = false;
+                this._invokeDrainCallback();
+              }
             });
           }
         }, this.FLUSH_INTERVAL);


### PR DESCRIPTION
`writeChunk()` sets `flushBackpressure = true` on backpressure, clears it and invokes `pendingDrainCallback` when `onWritable` drains or timeout flush succeeds.

`onAborted` clears `flushBackpressure` and invokes pending drain callback with error so Writable doesn't hang.

Fix #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for backpressure handling during response writes.

* **Bug Fixes**
  * Improved backpressure tracking and drain callback management in response handling.
  * Enhanced error handling for aborted connections during backpressure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->