### PR TITLE
fix: suppress false-positive ERROR log on client-abort in handleException

### DIFF
--- a/src/http/routing/route-registry.spec.ts
+++ b/src/http/routing/route-registry.spec.ts
@@ -361,6 +361,30 @@ describe('RouteRegistry', () => {
   });
 
   describe('error handling', () => {
+    it('should silently ignore "Connection aborted" errors', async () => {
+      const loggerErrorSpy = jest.fn();
+      const mockLogger = { error: loggerErrorSpy };
+
+      const registryWithLogger = new RouteRegistry(mockUwsApp, {
+        maxBodySize: 1024 * 1024,
+        logger: mockLogger,
+      });
+
+      const handler = jest.fn().mockRejectedValue(new Error('Connection aborted'));
+      registryWithLogger.register('GET', '/abort', handler);
+
+      const uwsHandler = registeredRoutes.get('GET:/abort')?.handler;
+      expect(uwsHandler).toBeDefined();
+
+      const { mockUwsRes, mockUwsReq } = createMockUwsReqRes();
+      await uwsHandler!(mockUwsRes, mockUwsReq);
+
+      // Must NOT log — client disconnect is not a server error
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      // Must NOT attempt to send a 500 response
+      expect(mockUwsRes.writeStatus).not.toHaveBeenCalledWith('500 Internal Server Error');
+    });
+
     it('should handle errors in route handler', async () => {
       const handler = jest.fn().mockRejectedValue(new Error('Handler error'));
       registry.register('GET', '/error', handler);

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -588,6 +588,11 @@ export class RouteRegistry {
     handler: RouteHandler,
     metadata?: RouteMetadata
   ): Promise<void> {
+    // Client disconnected mid-request — not a server error, nothing to log or respond to.
+    if (res.isAborted || error.message === 'Connection aborted') {
+      return;
+    }
+
     // Log error for debugging (server-side only)
     this.logger.error('Unhandled route error:', error);
 


### PR DESCRIPTION
## Problem

When a client disconnects mid-request, `BodyParser` rejects with `"Connection aborted"`. `RouteRegistry.executeHandler()` catches this and calls `handleException()`, which was logging it as an unhandled server error:

```
Unhandled route error: Error: Connection aborted
```

Then it tried to send a 500 response, which `UwsResponse.send()` silently dropped because `this.aborted` was already `true`. So the log was pure noise — no response was sent, no crash occurred, nothing needed to be "handled."

## Fix

Add an early-return guard at the top of `handleException()`:

```typescript
if (res.isAborted || error.message === 'Connection aborted') {
  return;
}
```

This matches the pattern already used throughout the rest of the file (e.g. lines 279, 322–325, 373, 956, 967) for the aborted state.

## Test

Added a regression test to `route-registry.spec.ts` that verifies `logger.error` is **not** called when the handler rejects with `"Connection aborted"`.

**All 948 existing tests still pass.**

Closes #163