### PR TITLE
chore: update eslint ignore patterns to match in subdirectories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ const sharedRules = {
 export default [
   // Ignore patterns
   {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '*.config.js', '*.config.mjs', 'benchmarks/node_modules/'],
+    ignores: ['**/dist/', '**/node_modules/', '**/coverage/', '**/*.config.js', '**/*.config.mjs', '**/benchmarks/node_modules/'],
   },
 
   // Base ESLint recommended rules


### PR DESCRIPTION
Fixes issue #167 

## Description
Updated the ignore patterns in `eslint.config.mjs` to include the `**/` prefix. 

Previously, patterns like `dist/` and `node_modules/` were only matching directories at the root level of the project. This change ensures that ESLint correctly ignores these directories and generated config files regardless of how deeply nested they are within the project structure.

## Changes Made
- Added `**/` prefix to all ignore patterns in the ESLint flat config.
