### PR TITLE
fix(routing): match trailing-slash paths for Express compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 
+## [2.0.1] - 2026-05-20
+
+### Fixed
+- trailing slash routes return 404 #182
+
 ## [2.0.0] - 2026-05-20
 
 ### Added
@@ -149,6 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exception handling with WsException class
 - Broadcast operator with room targeting and client exclusion
 
-[Unreleased]: https://github.com/FOSSFORGE/uWestJS/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/FOSSFORGE/uWestJS/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/FOSSFORGE/uWestJS/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/FOSSFORGE/uWestJS/compare/v1.0.1...v2.0.0
 [1.0.1]: https://github.com/FOSSFORGE/uWestJS/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/FOSSFORGE/uWestJS/releases/tag/v1.0.0

--- a/src/http/routing/route-registry.spec.ts
+++ b/src/http/routing/route-registry.spec.ts
@@ -97,7 +97,7 @@ describe('RouteRegistry', () => {
       registry.register('GET', '/items/:id', getHandler);
       registry.register('HEAD', '/items/:id', headHandler);
 
-      expect(mockUwsApp.head).toHaveBeenCalledTimes(1);
+      expect(mockUwsApp.head).toHaveBeenCalledTimes(2);
 
       const route = registeredRoutes.get('HEAD:/items/:id');
       expect(route).toBeDefined();

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -85,6 +85,7 @@ export interface RouteInfo {
   handler: RouteHandler; // Store the handler
   metadata?: RouteMetadata; // Middleware metadata
   implicitHead?: boolean; // Auto-registered HEAD fallback for GET routes
+  trailingSlash?: boolean; // Auto-registered trailing-slash variant for Express compatibility
 }
 
 /**
@@ -252,6 +253,11 @@ export class RouteRegistry {
         };
 
         this.routes.set(routeKey, routeInfo);
+        // Also update trailing-slash variant if it exists
+        const slashRouteKey = `${normalizedMethod}:${path}/`;
+        if (this.routes.has(slashRouteKey)) {
+          this.routes.set(slashRouteKey, { ...routeInfo, trailingSlash: true });
+        }
         if (isComplex) {
           const staticPrefix = this.extractStaticPrefix(path);
           const registrationPath = staticPrefix ? `${staticPrefix}/*` : '/*';
@@ -385,11 +391,9 @@ export class RouteRegistry {
       this.complexRoutesByWildcard.get(wildcardKey)!.push(routeInfo);
     } else {
       // Simple route - use native uWS routing
-      uwsMethodFn.call(
-        this.uwsApp,
-        uwsPath,
-        async (uwsRes: uWS.HttpResponse, uwsReq: uWS.HttpRequest) => {
-          const activeRoute = this.routes.get(routeKey)!;
+      const createHandler =
+        (key: string) => async (uwsRes: uWS.HttpResponse, uwsReq: uWS.HttpRequest) => {
+          const activeRoute = this.routes.get(key)!;
 
           // Create request/response wrappers
           const req = new UwsRequest(uwsReq, uwsRes, paramNames);
@@ -414,8 +418,26 @@ export class RouteRegistry {
 
           // Execute handler with error handling
           await this.executeHandler(activeRoute.handler, req, res, activeRoute.metadata);
+        };
+
+      uwsMethodFn.call(this.uwsApp, uwsPath, createHandler(routeKey));
+
+      // Also register trailing-slash variant for Express compatibility
+      // (e.g. /api and /api/ should both match the same route)
+      if (!uwsPath.endsWith('/') && uwsPath !== '/') {
+        const slashRouteKey = `${normalizedMethod}:${path}/`;
+        if (!this.routes.has(slashRouteKey)) {
+          this.routes.set(slashRouteKey, { ...routeInfo, trailingSlash: true });
+          uwsMethodFn.call(this.uwsApp, uwsPath + '/', createHandler(slashRouteKey));
         }
-      );
+      } else if (uwsPath.endsWith('/') && uwsPath !== '/') {
+        const nonTrailingPath = uwsPath.slice(0, -1);
+        const companionKey = `${normalizedMethod}:${path.slice(0, -1)}`;
+        if (!this.routes.has(companionKey)) {
+          this.routes.set(companionKey, { ...routeInfo, trailingSlash: false });
+          uwsMethodFn.call(this.uwsApp, nonTrailingPath, createHandler(companionKey));
+        }
+      }
     }
 
     if (normalizedMethod === 'GET' && !implicitHead) {
@@ -935,7 +957,11 @@ export class RouteRegistry {
    * @returns Map of route keys to route information
    */
   getRoutes(): Map<string, RouteInfo> {
-    return new Map([...this.routes].filter(([, route]) => !route.implicitHead));
+    return new Map(
+      [...this.routes].filter(
+        ([, route]) => !route.implicitHead && route.trailingSlash === undefined
+      )
+    );
   }
 
   /**
@@ -957,7 +983,9 @@ export class RouteRegistry {
    * @returns Number of registered routes
    */
   getRouteCount(): number {
-    return [...this.routes.values()].filter((route) => !route.implicitHead).length;
+    return [...this.routes.values()].filter(
+      (route) => !route.implicitHead && route.trailingSlash === undefined
+    ).length;
   }
 
   private replaceComplexRoute(wildcardKey: string, routeInfo: RouteInfo): void {


### PR DESCRIPTION
Auto-registers a trailing-slash variant for all simple routes (e.g. `/api` → also registers `/api/`). Derived routes are tagged with `trailingSlash: true` so they stay hidden from `getRoutes()` / `getRouteCount()`. Explicit HEAD overrides now also update the trailing-slash variant if one exists.

uWebSockets.js uses exact-path routing, so `/api/` returned 404 even though `/api` worked. Express treats both as the same route by default.

Fixes #182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed 404 errors when accessing routes with trailing slashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->