### PR TITLE
fix: support wildcard accept-encoding negotiation

### DIFF
--- a/src/http/handlers/compression/compression-handler.spec.ts
+++ b/src/http/handlers/compression/compression-handler.spec.ts
@@ -549,6 +549,36 @@ describe('CompressionHandler', () => {
         verifyDecompression(compressed, LARGE_DATA, 'brotli');
       });
 
+      it('should expand wildcard accept-encoding to supported encodings', async () => {
+        const handler = new CompressionHandler({ brotli: true });
+        setupMock('*', 'text/plain');
+
+        const compressed = await handler.compressBuffer(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(compressed).not.toBe(LARGE_DATA);
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'br');
+        verifyDecompression(compressed, LARGE_DATA, 'brotli');
+      });
+
+      it('should not re-enable encodings explicitly rejected before wildcard expansion', async () => {
+        const handler = new CompressionHandler();
+        setupMock('gzip;q=0, *', 'text/plain');
+
+        const compressed = await handler.compressBuffer(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(compressed).not.toBe(LARGE_DATA);
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'deflate');
+        verifyDecompression(compressed, LARGE_DATA, 'deflate');
+      });
+
       it('should return original buffer when compression not needed', async () => {
         const handler = new CompressionHandler();
         setupMock('gzip', 'text/plain');

--- a/src/http/handlers/compression/compression-handler.ts
+++ b/src/http/handlers/compression/compression-handler.ts
@@ -429,6 +429,8 @@ export class CompressionHandler {
    */
   private parseAcceptEncoding(acceptEncoding: string): string[] {
     const encodings: Array<{ encoding: string; quality: number; position: number }> = [];
+    const rejected = new Set<string>();
+    let wildcardQuality: number | null = null;
 
     // Encoding preference order (higher is better)
     const encodingPriority: Record<string, number> = {
@@ -436,6 +438,7 @@ export class CompressionHandler {
       gzip: 2, // Gzip - good compression
       deflate: 1, // Deflate - basic compression
     };
+    const supportedEncodings = Object.keys(encodingPriority);
 
     // Parse encodings with quality values
     const parts = acceptEncoding.split(',');
@@ -445,7 +448,7 @@ export class CompressionHandler {
         .trim()
         .split(';')
         .map((t) => t.trim());
-      const encoding = tokens[0];
+      const encoding = tokens[0].toLowerCase();
 
       // Find q parameter specifically (case-insensitive)
       const qToken = tokens.slice(1).find((t) => t.toLowerCase().startsWith('q='));
@@ -456,12 +459,29 @@ export class CompressionHandler {
         quality = Number.isNaN(parsed) ? 1.0 : Math.min(1, Math.max(0, parsed));
       }
 
-      if (quality > 0) {
+      if (encoding === '*') {
+        wildcardQuality = quality;
+      } else if (quality > 0) {
         encodings.push({
-          encoding: encoding.trim().toLowerCase(),
+          encoding,
           quality,
           position: i, // Track position for stable sort
         });
+      } else {
+        rejected.add(encoding);
+      }
+    }
+
+    if (wildcardQuality !== null && wildcardQuality > 0) {
+      for (const encoding of supportedEncodings) {
+        const isAlreadyListed = encodings.some((entry) => entry.encoding === encoding);
+        if (!isAlreadyListed && !rejected.has(encoding)) {
+          encodings.push({
+            encoding,
+            quality: wildcardQuality,
+            position: Number.MAX_SAFE_INTEGER,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- expand `Accept-Encoding: *` into supported compression encodings during negotiation
- keep explicitly rejected encodings (for example `gzip;q=0`) excluded from wildcard expansion
- add regression coverage for wildcard compression and rejection behavior

Closes #193

## Verification
- `npm test -- --runInBand src/http/handlers/compression/compression-handler.spec.ts`
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP compression negotiation to correctly handle wildcard (`*`) Accept-Encoding preferences, properly expanding them to supported compression methods while respecting explicitly rejected encodings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FOSSFORGE/uWestJS/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->