### PR TITLE
Fix: handle Accept-Encoding wildcard (*) per RFC 7231

### DIFF
--- a/src/http/handlers/compression/compression-handler.spec.ts
+++ b/src/http/handlers/compression/compression-handler.spec.ts
@@ -337,6 +337,80 @@ describe('CompressionHandler', () => {
         expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'deflate');
       });
 
+      it('should compress response when Accept-Encoding is wildcard (*)', () => {
+        const handler = new CompressionHandler({ brotli: true });
+        setupMock('*', 'text/plain');
+
+        const stream = handler.createCompressionStream(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(stream).toBeInstanceOf(Transform);
+        // Should pick brotli as highest priority supported encoding
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'br');
+      });
+
+      it('should expand wildcard to supported encodings not explicitly listed', () => {
+        const handler = new CompressionHandler();
+        setupMock('gzip, *', 'text/plain');
+
+        const stream = handler.createCompressionStream(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(stream).toBeInstanceOf(Transform);
+        // gzip explicitly listed with higher priority than wildcard-expanded encodings
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'gzip');
+      });
+
+      it('should respect explicitly rejected encodings with wildcard', () => {
+        const handler = new CompressionHandler();
+        setupMock('gzip;q=0, *', 'text/plain');
+
+        const stream = handler.createCompressionStream(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(stream).toBeInstanceOf(Transform);
+        // gzip rejected (q=0), wildcard should expand to deflate only (brotli not enabled)
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'deflate');
+      });
+
+      it('should respect explicitly rejected encodings with wildcard when brotli enabled', () => {
+        const handler = new CompressionHandler({ brotli: true });
+        setupMock('gzip;q=0, *', 'text/plain');
+
+        const stream = handler.createCompressionStream(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(stream).toBeInstanceOf(Transform);
+        // gzip rejected (q=0), wildcard expands to br and deflate
+        // br has highest priority
+        expect(setHeaderSpy).toHaveBeenCalledWith('content-encoding', 'br');
+      });
+
+      it('should return null for wildcard with all supported encodings rejected', () => {
+        const handler = new CompressionHandler();
+        setupMock('gzip;q=0, deflate;q=0, *;q=0', 'text/plain');
+
+        const stream = handler.createCompressionStream(
+          mockReq as UwsRequest,
+          mockRes as UwsResponse,
+          LARGE_DATA
+        );
+
+        expect(stream).toBeNull();
+      });
+
       it('should create stream without body check when body not provided', () => {
         const handler = new CompressionHandler();
         setupMock('gzip', 'text/plain');

--- a/src/http/handlers/compression/compression-handler.ts
+++ b/src/http/handlers/compression/compression-handler.ts
@@ -429,6 +429,9 @@ export class CompressionHandler {
    */
   private parseAcceptEncoding(acceptEncoding: string): string[] {
     const encodings: Array<{ encoding: string; quality: number; position: number }> = [];
+    const explicitlyRejected: Set<string> = new Set();
+    let hasWildcard = false;
+    let wildcardQuality = 0;
 
     // Encoding preference order (higher is better)
     const encodingPriority: Record<string, number> = {
@@ -456,12 +459,34 @@ export class CompressionHandler {
         quality = Number.isNaN(parsed) ? 1.0 : Math.min(1, Math.max(0, parsed));
       }
 
-      if (quality > 0) {
+      if (encoding === '*') {
+        hasWildcard = true;
+        wildcardQuality = quality;
+      } else if (quality === 0) {
+        explicitlyRejected.add(encoding.trim().toLowerCase());
+      } else {
         encodings.push({
           encoding: encoding.trim().toLowerCase(),
           quality,
           position: i, // Track position for stable sort
         });
+      }
+    }
+
+    // If we have a wildcard with quality > 0, expand it to supported encodings
+    // per RFC 7231: Accept-Encoding: * means the client accepts any encoding
+    if (hasWildcard && wildcardQuality > 0) {
+      const supportedEncodings = Object.keys(encodingPriority);
+
+      for (const encoding of supportedEncodings) {
+        const isExplicitlyListed = encodings.some((e) => e.encoding === encoding);
+        if (!isExplicitlyListed && !explicitlyRejected.has(encoding)) {
+          encodings.push({
+            encoding,
+            quality: wildcardQuality,
+            position: parts.length, // Place wildcard entries after explicit ones
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Per RFC 7231, `Accept-Encoding: *` means the client accepts any encoding. Currently, `CompressionHandler.parseAcceptEncoding` treats the `*` wildcard as an unknown token, so responses to `Accept-Encoding: *` requests are sent uncompressed.

## Changes

- Track the `*` wildcard token separately during parsing with its quality value
- Track explicitly rejected encodings (`q=0`) in a Set
- After parsing explicit entries, expand the wildcard into supported encodings (`br`, `gzip`, `deflate`) that are not already explicitly listed or rejected
- Preserve the wildcard quality value for expanded encodings
- Handle edge case: `Accept-Encoding: gzip;q=0, *` correctly excludes gzip from wildcard expansion while still using deflate/brotli

## Test Coverage

Added 5 new test cases:
- Wildcard `*` selects best available encoding (brotli when enabled)
- Wildcard expands to fill gaps alongside explicit encodings
- Explicitly rejected encodings (`q=0`) are excluded from wildcard expansion
- Full integration with brotli enabled/disabled configurations
- All encodings rejected returns `null` (no compression)

All 70 tests pass (65 existing + 5 new).

Fixes #193