### PR TITLE
fix: preserve body size limit error in fast-abort mode

### DIFF
--- a/src/http/body/body-parser.spec.ts
+++ b/src/http/body/body-parser.spec.ts
@@ -173,6 +173,53 @@ describe('BodyParser', () => {
       // Connection should be closed
       expect(mockUwsRes.close).toHaveBeenCalled();
     });
+
+    it('should preserve original error when size limit exceeded before abort', async () => {
+      // When maxBodySize is exceeded in fastAbort mode, the "Body size limit exceeded"
+      // error should be preserved even if onAborted fires and tries to overwrite it
+      const headers = { 'content-length': '100' };
+      const parser = new BodyParser(mockUwsRes, headers, 50);
+
+      const bufferPromise = parser.buffer();
+
+      // Send chunk that exceeds limit (triggers fastAbort path)
+      const chunk = Buffer.alloc(60);
+      onDataCallback(toArrayBuffer(chunk), false);
+
+      // Simulate onAborted firing after the limit was exceeded
+      // This should NOT overwrite the original error
+      onAbortedCallback();
+
+      // The error should still be "Body size limit exceeded", not "Connection aborted"
+      await expect(bufferPromise).rejects.toThrow('Body size limit exceeded');
+
+      // Subsequent buffer() calls should also preserve the original error
+      await expect(parser.buffer()).rejects.toThrow('Body size limit exceeded');
+    });
+
+    it('should preserve original error even when onAborted overwrites would occur', async () => {
+      // Verify that abortError is not overwritten when already set
+      const headers = { 'content-length': '100' };
+      const parser = new BodyParser(mockUwsRes, headers, 50);
+
+      const bufferPromise = parser.buffer();
+
+      // Send chunk exceeding limit
+      const chunk = Buffer.alloc(60);
+      onDataCallback(toArrayBuffer(chunk), false);
+
+      // Trigger abort after limit was exceeded
+      onAbortedCallback();
+
+      // Error should be "Body size limit exceeded" not "Connection aborted"
+      try {
+        await bufferPromise;
+        fail('Expected promise to reject');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe('Body size limit exceeded');
+      }
+    });
   });
 
   describe('buffer()', () => {

--- a/src/http/body/body-parser.ts
+++ b/src/http/body/body-parser.ts
@@ -83,7 +83,12 @@ export class BodyParser {
       // Without this, promises will hang forever if connection is aborted
       uwsRes.onAborted(() => {
         this.aborted = true;
-        this.abortError = new Error('Connection aborted');
+        // Only set abortError if not already set (e.g., by size limit enforcement)
+        // This preserves the original error message ("Body size limit exceeded")
+        // instead of overwriting it with a generic "Connection aborted"
+        if (!this.abortError) {
+          this.abortError = new Error('Connection aborted');
+        }
         this.flushing = true; // Stop processing chunks
 
         // abortCallback handles client disconnects
@@ -134,6 +139,9 @@ export class BodyParser {
     if (this.receivedBytes > this.limitBytes) {
       this.flushing = true;
       const error = new Error('Body size limit exceeded');
+
+      // Preserve the original error before onAborted can overwrite it
+      this.abortError = error;
 
       // Reject any pending promise
       if (this.pendingReject) {


### PR DESCRIPTION
## Summary

Fixes #186 — When `processDecompressedChunk` hits `maxBodySize` in `fastAbort` mode, the original `Body size limit exceeded` error was being overwritten by `Connection aborted` when the `onAborted` callback fired.

## Problem

1. In the size limit enforcement path (`onChunk`), `uwsRes.close()` was called without first setting `this.abortError`, so when `onAborted` fired, it unconditionally overwrote the error with `Connection aborted`
2. In test mocks where `close()` does not trigger `onAborted`, pending promises could hang forever

## Changes

1. Set `this.abortError` to the `Body size limit exceeded` error **before** calling `uwsRes.close()` in the size limit path
2. Guard `this.abortError` assignment in `onAborted` to only set it when not already set:

```typescript
if (!this.abortError) {
  this.abortError = new Error("Connection aborted");
}
```

## Testing

- All 70 existing tests pass
- Added 2 new test cases:
  - `should preserve original error when size limit exceeded before abort`
  - `should preserve original error even when onAborted overwrites would occur`

Both tests verify that `buffer()` rejects with `Body size limit exceeded` even after `onAborted` fires, not `Connection aborted`.