### PR TITLE
refactor: simplify param decorator lookup and document CORS pipeline step

### DIFF
--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -449,6 +449,7 @@ export class RouteRegistry {
    * Execute a route handler with middleware pipeline
    *
    * Executes the full middleware pipeline:
+   * 0. CORS - Handle CORS headers and preflight
    * 1. Guards - Authorization checks
    * 2. Body parsing - Parse request body if present
    * 3. Pipes - Transform/validate body

--- a/src/websocket/decorators/param-decorator.utils.ts
+++ b/src/websocket/decorators/param-decorator.utils.ts
@@ -71,9 +71,8 @@ export function createParamDecorator(
     ];
 
     // Check if this parameter index already has metadata
-    const existingIndex = existingParams.findIndex((p) => p.index === parameterIndex);
-    if (existingIndex !== -1) {
-      const existing = existingParams[existingIndex];
+    const existing = existingParams.find((p) => p.index === parameterIndex);
+    if (existing) {
       const existingDecoratorName = PARAM_TYPE_TO_DECORATOR_NAME[existing.type];
       throw new Error(
         `${decoratorName} decorator: parameter at index ${parameterIndex} already has @${existingDecoratorName} decorator applied. ` +


### PR DESCRIPTION
## Summary

Two small improvements addressing #192 and #190:

### #192: Simplify param decorator duplicate check

Replace `findIndex` + array indexing with `find()` for cleaner parameter metadata lookup in `param-decorator.utils.ts`.

**Before:**
```typescript
const existingIndex = existingParams.findIndex((p) => p.index === parameterIndex);
if (existingIndex !== -1) {
  const existing = existingParams[existingIndex];
```

**After:**
```typescript
const existing = existingParams.find((p) => p.index === parameterIndex);
if (existing) {
```

Same behavior, less indirection.

### #190: Document CORS as step 0 in middleware pipeline

The JSDoc for `RouteRegistry.executeHandler` listed steps 1–5 but omitted step 0 (CORS handling), which the code actually executes before guards. Added step 0 to make the documentation consistent with the inline code comment (`// 0. Handle CORS if enabled`).

## Testing

All 956 tests pass.