### PR TITLE
docs: warn about empty-object UwsSocketImpl.data cast at class level (#191)

### DIFF
--- a/src/websocket/core/socket.ts
+++ b/src/websocket/core/socket.ts
@@ -4,8 +4,15 @@ import { RoomManager } from '../rooms';
 import { BroadcastOperator } from './broadcast-operator';
 
 /**
- * Socket wrapper that provides a Socket.IO-like API over native uWebSockets.js
- * This class wraps the native uWS.WebSocket and adds convenient methods
+ * Socket wrapper that provides a Socket.IO-like API over native uWebSockets.js.
+ * This class wraps the native uWS.WebSocket and adds convenient methods.
+ *
+ * IMPORTANT: `data` is initialized as an empty object cast to `TData`. The cast
+ * is safe for object types without required fields (the common case) but is
+ * unsafe when `TData` is a primitive type or has required properties: reading
+ * `socket.data` before assigning to it will surface a partially-typed value.
+ * Always assign `socket.data` before reading it in those cases.
+ *
  * @template TData - Type of custom data attached to the socket
  * @template TEmitData - Type of data that can be emitted
  */


### PR DESCRIPTION
## Summary

`UwsSocketImpl` initializes `_data = {} as TData` in its constructor. That cast is safe for object `TData` without required fields (the common case), but it silently lies for primitive `TData` or types with required properties: `socket.data` then reads as `{}` typed at `TData`, and the caller is none the wiser.

The `data` getter already mentions this caveat, but readers browsing the class for an API overview easily miss the per-property note. Lift the warning to the class-level JSDoc so it shows up in IntelliSense, generated API docs, and the rendered class documentation alongside the rest of the description.

## Changes

- `src/websocket/core/socket.ts`: extend the `UwsSocketImpl` class JSDoc with the "set `socket.data` before reading it for primitive / required-field `TData`" caveat lifted from the `data` getter's existing note.

Closes #191
